### PR TITLE
feat: masatomix/task と同様の GitFlow 運用基盤を導入 (#13)

### DIFF
--- a/.claude/skills/create-branch/SKILL.md
+++ b/.claude/skills/create-branch/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: create-branch
+description: GitFlowに従ってブランチを作成。「ブランチを作って」「Issue着手」「#42に着手」「このIssueをやる」「タスクを始める」「作業開始」「着手する」「対応する」「取り掛かる」「GitFlowで」「hotfixで」「featureで」などと言われた時に使用。
+---
+
+# ブランチ作成スキル（worktree方式）
+
+worktreeを使ってfeature/hotfixブランチを作成する。メインリポジトリ（keyball/）は常にdevelopブランチを維持する。
+
+---
+
+## worktree構成
+
+```
+~/git/
+├── keyball/                         # developブランチ（常にdevelopを維持）
+├── keyball-feature-{issue番号}/     # featureブランチ用worktree
+└── keyball-hotfix-{説明}/           # hotfixブランチ用worktree
+```
+
+---
+
+## 実行手順
+
+### Step 1: ブランチ種別を確認
+
+ユーザーに確認：
+- **feature**: Issue対応、新機能、タスク → Issue番号が必要
+- **hotfix**: 軽微な修正、緊急対応 → Issue番号不要
+
+### Step 2: 必要情報を収集
+
+**featureの場合:**
+- Issue番号（必須）
+- 短い説明（英語、ケバブケース推奨）
+
+**hotfixの場合:**
+- 短い説明（英語、ケバブケース推奨）
+
+### Step 3: developブランチを最新化
+
+```bash
+cd /Users/masatomix/git/keyball
+git checkout develop
+git pull origin develop
+```
+
+### Step 4: worktreeを作成
+
+**featureブランチの場合:**
+```bash
+git worktree add -b feature/{issue番号}-{説明} ../keyball-feature-{issue番号} develop
+```
+
+例:
+```bash
+git worktree add -b feature/42-add-user-auth ../keyball-feature-42 develop
+```
+
+**hotfixブランチの場合:**
+```bash
+git worktree add -b hotfix/{説明} ../keyball-hotfix-{説明} develop
+```
+
+例:
+```bash
+git worktree add -b hotfix/fix-typo ../keyball-hotfix-fix-typo develop
+```
+
+### Step 5: 完了案内
+
+作成完了後、以下を案内：
+
+```
+worktreeを作成しました:
+- ブランチ: feature/{issue番号}-{説明}
+- パス: /Users/masatomix/git/keyball-feature-{issue番号}
+
+作業を開始するには:
+  cd /Users/masatomix/git/keyball-feature-{issue番号}
+
+作業完了後のクリーンアップ:
+  cd /Users/masatomix/git/keyball
+  git worktree remove ../keyball-feature-{issue番号}
+  git branch -D feature/{issue番号}-{説明}
+  git push origin --delete feature/{issue番号}-{説明}
+  git pull origin develop
+```
+
+---
+
+## 注意事項
+
+- メインリポジトリ（/Users/masatomix/git/keyball）では直接作業しない
+- worktree内で作業・コミット・プッシュを行う
+- PRマージ後は必ずworktreeを削除する
+- PRのベースブランチは `develop` を指定する
+- 既存のworktreeがある場合は `git worktree list` で確認
+
+---
+
+## 参考コマンド
+
+```bash
+# worktree一覧を確認
+git worktree list
+
+# worktreeを削除
+git worktree remove ../keyball-feature-{issue番号}
+
+# 強制削除（未コミットの変更がある場合）
+git worktree remove --force ../keyball-feature-{issue番号}
+
+# リモートブランチの削除
+git push origin --delete feature/{issue番号}-{説明}
+```

--- a/.claude/task-config.json.template
+++ b/.claude/task-config.json.template
@@ -1,0 +1,5 @@
+{
+  "repository": "masatomix/keyball",
+  "project_number": 1,
+  "default_assignee": "masatomix"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,82 @@
 
 このファイルはClaude Code (claude.ai/code) がこのリポジトリで作業する際のガイダンスを提供します。
 
+---
+
+## ⚠️ 最重要ルール: GitFlow 厳守
+
+**すべての変更（コード、ドキュメント問わず）は以下の手順を守ること:**
+
+1. **作業開始前に必ずブランチを作成**（`/create-branch` スキルを使用）
+2. ブランチ上で作業・コミット
+3. PRを作成してマージ（ベースブランチ: `develop`）
+4. マージ後にクリーンアップ（worktree削除、リモートブランチ削除）
+
+### ブランチ命名規則
+- `feature/{issue番号}-{説明}` — 新機能、タスク対応
+- `hotfix/{説明}` — 軽微な修正、緊急対応
+
+```bash
+# ❌ 絶対禁止
+git commit  # develop/mainブランチで直接コミット
+git push origin develop
+git push origin main
+```
+
+**develop/mainブランチでの直接コミット・プッシュは禁止。必ずブランチ経由でPRを作成すること。**
+
+### worktree 構成
+
+```
+~/git/
+├── keyball/                         # developブランチ（常にdevelopを維持）
+├── keyball-feature-{issue番号}/     # featureブランチ用worktree
+└── keyball-hotfix-{説明}/           # hotfixブランチ用worktree
+```
+
+メインリポジトリ（`~/git/keyball/`）では直接作業しない。worktree内で作業・コミット・プッシュを行う。
+
+### タスク管理ワークフロー
+
+```
+[Issue作成] → [ブランチ作成(/create-branch)] → [作業・コミット] → [PR作成] → [マージ] → [クリーンアップ]
+```
+
+#### 設定ファイル
+
+`.claude/task-config.json` に設定を保存（テンプレート: `.claude/task-config.json.template`）
+
+```bash
+CONFIG_FILE=".claude/task-config.json"
+REPO=$(jq -r '.repository' "$CONFIG_FILE")
+```
+
+#### タスク着手
+
+1. **最初に `/create-branch` スキルを実行してブランチを作成**
+   - ⚠️ `git checkout -b` や `git branch` を直接使用してはならない
+   - 必ず `/create-branch` スキルを使用すること
+2. worktree 内で作業
+3. 変更をコミット・プッシュ
+4. PR作成（`Closes #番号` を含める → マージ時にIssue自動Close）
+
+```bash
+git push -u origin {ブランチ名}
+gh pr create --repo "$REPO" --title "feat: 機能説明 (#番号)" --body "Closes #番号" --base develop
+```
+
+#### クリーンアップ
+
+```bash
+cd ~/git/keyball
+git worktree remove ../keyball-feature-{issue番号}
+git branch -D feature/{issue番号}-{説明}
+git push origin --delete feature/{issue番号}-{説明}
+git pull origin develop
+```
+
+---
+
 ## プロジェクト概要
 
 QMK (Quantum Mechanical Keyboard) ファームウェアはAVR・ARMマイコン向けのオープンソースキーボードファームウェア。レイヤーキーマップシステム、マクロ、RGB照明、オーディオ、OLEDディスプレイ、ポインティングデバイスなどの機能をサポートしている。


### PR DESCRIPTION
## 概要

masatomix/task リポジトリと同様の GitFlow 運用基盤を keyball リポジトリにも導入する。

Closes #13

## 変更内容

- **CLAUDE.md**: GitFlow 厳守ルール・worktree 構成・タスク管理ワークフローセクションを追加
- **.claude/task-config.json.template**: リポジトリ設定テンプレートを新規作成
- **.claude/skills/create-branch/SKILL.md**: worktree 方式のブランチ作成スキルを keyball 用にカスタマイズして新規作成

## 受け入れ条件

- [x] CLAUDE.md に GitFlow 厳守ルール追加
- [x] `.claude/task-config.json.template` を作成
- [x] `.claude/skills/create-branch/SKILL.md` を keyball 用にカスタマイズして作成
- [ ] GitHub Projects（カンバン）のセットアップを案内

## 備考

- ベースブランチは `develop`（keyball は GitFlow で develop を統合ブランチとして使用）
- worktree パスは `~/git/keyball-feature-{issue番号}/` 形式
- GitHub Projects のセットアップは別途ユーザーに案内予定