### PR TITLE
fix: task-config の project_number を 6 に修正 (#15)

### DIFF
--- a/.claude/task-config.json.template
+++ b/.claude/task-config.json.template
@@ -1,5 +1,5 @@
 {
   "repository": "masatomix/keyball",
-  "project_number": 1,
+  "project_number": 6,
   "default_assignee": "masatomix"
 }


### PR DESCRIPTION
## Summary
- `.claude/task-config.json.template` の `project_number` を `1` → `6` に変更
- 既存の GitHub Projects #6 (Task Project) を keyball リポジトリでも共用するため

Closes #15