### PR TITLE
feat(keyball44): Mac/Win キーマップ共通化 (#598)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
@@ -40,16 +40,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 #define POINTING_DEVICE_AUTO_MOUSE_ENABLE // 有効化
-#define AUTO_MOUSE_DEFAULT_LAYER 3 // 切り替えるマウスレイヤー番号を指定
+#define AUTO_MOUSE_DEFAULT_LAYER 4 // 切り替えるマウスレイヤー番号を指定 (L_MOUSE)
 #define AUTO_MOUSE_TIME 400 // マウスが止まってから元のレイヤーに戻るまでの時間(ms)
 
 
-#define LAYER_LED_ENABLE
+// #define LAYER_LED_ENABLE  // サイズ不足のため無効化
 
 #define PRECISION_ENABLE // 有効化
 #define PRECISION_CPI 3  // 下げた時のCPI (1/100の値を指定。左記ならCPI 300)
 
-#define DYNAMIC_KEYMAP_LAYER_COUNT 7
+#undef LAYER_STATE_8BIT
+#define LAYER_STATE_16BIT
+#define DYNAMIC_KEYMAP_LAYER_COUNT 8
 
 #define KEYBALL_SCROLLSNAP_ENABLE 0
 

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -32,53 +32,87 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 enum my_keyball_keycodes {
     LAY_TOG = KEYBALL_SAFE_RANGE,
     PRC_SW,                       // Precision モードスイッチ
+    MY_LAUNCH,                    // ランチャー (Mac: Alt+Esc, Win: Gui+Esc)
+    MY_RUN,                       // 実行 (Mac: Gui+R, Win: Win+R)
+    MY_SS1,                       // スクショ1 (Mac: Cmd+Shift+4, Win: Alt+PrtSc)
+    MY_SS2,                       // スクショ2 (Mac: Cmd+Shift+5, Win: PrtSc)
 };
+
+// Layer number definitions
+// Base layers (must be lower than shared/momentary layers)
+#define L_MAC_BASE  0
+#define L_WIN_BASE  1
+// Shared momentary layers
+#define L_NAV       2  // Navigation (Mac/Win shared)
+#define L_FKEYS     3  // F-keys (Mac/Win shared)
+#define L_MOUSE     4
+#define L_ALT_MOD   5
+#define L_MAC_SYM   6
+// Win momentary layer
+#define L_WIN_SYM   7
 
 // clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
-  // keymap for default (VIA)
-  [0] = LAYOUT_universal(
+  // Layer 0: Base QWERTY (Mac)
+  [L_MAC_BASE] = LAYOUT_universal(
     KC_TAB         , KC_Q       , KC_W     , KC_E     , KC_R      , KC_T ,                       KC_Y     , KC_U     , KC_I     , KC_O     , KC_P            , KC_EQL,
-    LCTL_T(KC_ESC) , KC_A       , KC_S     , KC_D     , LT(3,KC_F), KC_G ,                       KC_H     , KC_J     , KC_K     ,KC_L, RCMD_T(KC_SCLN) , RCTL_T(KC_QUOT),
-    KC_LSFT        , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , LT(3,KC_DOT)   , KC_SLSH         , RSFT_T(KC_BSLS),
-                    KC_LALT     , KC_LGUI  , MO(6)    ,LT(1,KC_SPC),LT(2,KC_LNG2),      LT(1,KC_BSPC),LT(4,KC_ENT), _______  ,  _______ , LT(6,KC_GRAVE)
+    LCTL_T(KC_ESC) , KC_A       , KC_S     , KC_D     , LT(L_MOUSE,KC_F), KC_G ,                KC_H     , KC_J     , KC_K     ,KC_L, RCMD_T(KC_SCLN) , RCTL_T(KC_QUOT),
+    KC_LSFT        , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , LT(L_MOUSE,KC_DOT)   , KC_SLSH         , RSFT_T(KC_BSLS),
+                    KC_LALT     , KC_LGUI  , MO(L_MAC_SYM)    ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      LT(L_NAV,KC_BSPC),LT(L_ALT_MOD,KC_ENT), _______  ,  _______ , LT(L_MAC_SYM,KC_GRAVE)
   ),
 
-  [1] = LAYOUT_universal(
+  // Layer 1: Base QWERTY (Win) - Alt/Gui swap, RCTL_T(;), layer refs to Win layers
+  [L_WIN_BASE] = LAYOUT_universal(
+    KC_TAB         , KC_Q       , KC_W     , KC_E     , KC_R      , KC_T ,                       KC_Y     , KC_U     , KC_I     , KC_O     , KC_P            , KC_EQL,
+    LCTL_T(KC_ESC) , KC_A       , KC_S     , KC_D     , LT(L_MOUSE,KC_F), KC_G ,                KC_H     , KC_J     , KC_K     ,KC_L, RCTL_T(KC_SCLN) , RCTL_T(KC_QUOT),
+    KC_LSFT        , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , LT(L_MOUSE,KC_DOT)   , KC_SLSH         , RSFT_T(KC_BSLS),
+                    KC_LGUI     , KC_LALT  , MO(L_WIN_SYM)    ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      LT(L_NAV,KC_BSPC),LT(L_ALT_MOD,KC_ENT), _______  ,  _______ , LT(L_WIN_SYM,KC_GRAVE)
+  ),
+
+  // Layer 2: Navigation (Mac/Win shared)
+  [L_NAV] = LAYOUT_universal(
     KC_F11   , LCTL(KC_UP ), LCTL(KC_DOWN), KC_PGUP  , KC_UP   , _______ ,                        _______ , _______  , _______   , KC_PGUP  , KC_UP     , _______ ,
-   S(KC_LCTL), KC_VOLD     , KC_VOLU      , KC_DEL   , KC_RGHT , LALT(KC_ESC) ,                   KC_BSPC , KC_DOWN  , KC_UP     , KC_RGHT  , _______   , _______ ,
+   S(KC_LCTL), KC_VOLD     , KC_VOLU      , KC_DEL   , KC_RGHT , MY_LAUNCH ,                      KC_BSPC , KC_DOWN  , KC_UP     , KC_RGHT  , _______   , _______ ,
     _______  , KC_BTN4     , KC_BTN5      , KC_PGDN  , KC_DOWN , KC_LEFT ,                        KC_DOWN , KC_LEFT  , _______   , KC_PGDN  , _______   , _______ ,
                _______     , _______      , _______  , _______ , _______ ,                        KC_DEL  , _______  , _______   , _______  , _______
   ),
 
-  [2] = LAYOUT_universal(
-    RGB_VAD  , RGB_VAI  , _______  , LGUI(KC_E)  , _______  , _______  ,                             _______  , SGUI(KC_4)    ,SGUI(KC_5), _______  , _______ , _______ ,
+  // Layer 3: F-keys (Mac/Win shared) + DF switch
+  [L_FKEYS] = LAYOUT_universal(
+    RGB_VAD  , RGB_VAI  , _______  , LGUI(KC_E)  , MY_RUN   , _______  ,                             _______  , MY_SS1   , MY_SS2   , _______  , DF(L_MAC_BASE)   , DF(L_WIN_BASE)   ,
     RGB_SAD  , RGB_SAI  , KC_F2    , KC_F3    , KC_F4    , KC_F5    ,                             KC_F6    , KC_F7    , KC_F8    , KC_F9    , KC_F10  , KC_F11  ,
     RGB_HUD  , RGB_HUI  , KC_F1    , _______  , LAY_TOG  , RGB_TOG  ,                             CPI_D100 , CPI_I100 , SCRL_DVD , SCRL_DVI , KBC_SAVE, KC_F12  ,
                _______  , _______  , _______  , _______  , _______  ,                             _______  , _______  , _______  , _______  , KBC_RST
   ),
 
-  [3] = LAYOUT_universal(
+  // Layer 4: Mouse (shared)
+  [L_MOUSE] = LAYOUT_universal(
     _______  , _______  , _______  , _______  , _______  , _______  ,                             _______  , _______  , _______  , _______  , _______ , _______ ,
     _______  , _______  , _______  , _______  , _______  , _______  ,                             _______  , KC_BTN1  , KC_BTN3  , KC_BTN2  , _______ , _______ ,
     _______  , KC_BTN4  , KC_BTN5  , _______  , _______  , PRC_SW   ,                             _______  , _______  , _______  , _______  , _______  , _______ ,
                _______  , _______  , _______  , KC_BTN1  , _______  ,                             _______  , _______  , _______  , _______  , _______
   ),
 
-  // Alt shortcuts (Enter hold)
-  [4] = LAYOUT_universal(
+  // Layer 5: Alt shortcuts (Enter hold) (shared)
+  [L_ALT_MOD] = LAYOUT_universal(
     _______  , _______  , _______  , _______  , _______     , LALT(KC_T),                             _______  , _______  , _______  , _______  , _______ , _______ ,
     _______  , _______  , _______  , _______  , _______     , _______  ,                             LALT(KC_H), LALT(KC_J), LALT(KC_K), LALT(KC_L), _______ , _______ ,
     _______  , _______  , LALT(KC_X), LALT(KC_C), LALT(KC_V), _______  ,                             _______  , _______  , _______  , _______  , _______  , _______ ,
                _______  , _______  , _______  , _______     , _______  ,                             _______  , _______  , _______  , _______  , _______
   ),
 
-  // Layer 5: unused
-
-
-  [6] = LAYOUT_universal(
+  // Layer 6: Symbols/Numbers (Mac)
+  [L_MAC_SYM] = LAYOUT_universal(
     S(KC_GRAVE)         , S(KC_1)  , S(KC_2)  , S(KC_3)   , S(KC_4) , S(KC_5) ,                   S(KC_6)  , S(KC_7)   , S(KC_8) , S(KC_9)  , S(KC_0)  , S(KC_MINS),
     LCTL_T(KC_GRAVE)    , KC_1     , KC_2     , KC_3      , KC_4    , KC_5    ,                   KC_6     , KC_7      , KC_8    , KC_9     , LCMD_T(KC_0) , RCTL_T(KC_MINS),
+    KC_LNG1  , KC_BTN4  , KC_BTN5  , _______  , S(KC_LBRC), KC_LBRC ,                             KC_RBRC  , S(KC_RBRC), _______ , _______  , _______  , _______ ,
+               _______  , _______  , _______  ,  _______  , _______ ,                             _______  , _______   , _______ , _______  , _______
+  ),
+
+  // Layer 7: Symbols/Numbers (Win) - ; position diff
+  [L_WIN_SYM] = LAYOUT_universal(
+    S(KC_GRAVE)         , S(KC_1)  , S(KC_2)  , S(KC_3)   , S(KC_4) , S(KC_5) ,                   S(KC_6)  , S(KC_7)   , S(KC_8) , S(KC_9)  , S(KC_0)  , S(KC_MINS),
+    LCTL_T(KC_GRAVE)    , KC_1     , KC_2     , KC_3      , KC_4    , KC_5    ,                   KC_6     , KC_7      , KC_8    , KC_9     , RCTL_T(KC_0) , RCTL_T(KC_MINS),
     KC_LNG1  , KC_BTN4  , KC_BTN5  , _______  , S(KC_LBRC), KC_LBRC ,                             KC_RBRC  , S(KC_RBRC), _______ , _______  , _______  , _______ ,
                _______  , _______  , _______  ,  _______  , _______ ,                             _______  , _______   , _______ , _______  , _______
   ),
@@ -86,8 +120,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // clang-format on
 
 layer_state_t layer_state_set_user(layer_state_t state) {
-    // Auto enable scroll mode when the highest layer is 6
-    keyball_set_scroll_mode(get_highest_layer(state) == 6);
+    // Auto enable scroll mode when the highest layer is Symbols (Mac:6 or Win:7)
+    uint8_t highest = get_highest_layer(state);
+    keyball_set_scroll_mode(highest == L_MAC_SYM || highest == L_WIN_SYM);
 
     #ifdef LAYER_LED_ENABLE
     change_layer_led_color(state);
@@ -95,7 +130,7 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
     #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
     switch(get_highest_layer(remove_auto_mouse_layer(state, true))) {
-        case 1:
+        case L_NAV:  // Navigation (shared)
             state = remove_auto_mouse_layer(state, false);
             set_auto_mouse_enable(false);
             break;
@@ -109,6 +144,11 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 }
 
 
+// OS判定ヘルパー
+static inline bool is_win_mode(void) {
+    return get_highest_layer(default_layer_state) == L_WIN_BASE;
+}
+
 // 切り替え処理
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
@@ -118,6 +158,46 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         #ifdef PRECISION_ENABLE
         case PRC_SW:  precision_switch(record->event.pressed); return false;
         #endif
+
+        case MY_LAUNCH:
+            if (record->event.pressed) {
+                if (is_win_mode()) {
+                    tap_code16(LGUI(KC_ESC));  // Win: Gui+Esc
+                } else {
+                    tap_code16(LALT(KC_ESC));  // Mac: Alt+Esc
+                }
+            }
+            return false;
+
+        case MY_RUN:
+            if (record->event.pressed) {
+                if (is_win_mode()) {
+                    tap_code16(LGUI(KC_R));    // Win: Win+R
+                } else {
+                    tap_code16(LGUI(KC_R));    // Mac: Cmd+R (同じキーコード)
+                }
+            }
+            return false;
+
+        case MY_SS1:
+            if (record->event.pressed) {
+                if (is_win_mode()) {
+                    tap_code16(LALT(KC_PSCR)); // Win: Alt+PrintScreen
+                } else {
+                    tap_code16(SGUI(KC_4));     // Mac: Cmd+Shift+4
+                }
+            }
+            return false;
+
+        case MY_SS2:
+            if (record->event.pressed) {
+                if (is_win_mode()) {
+                    tap_code16(KC_PSCR);       // Win: PrintScreen
+                } else {
+                    tap_code16(SGUI(KC_5));     // Mac: Cmd+Shift+5
+                }
+            }
+            return false;
 
         default: break;
     }

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/rules.mk
@@ -1,4 +1,4 @@
-RGBLIGHT_ENABLE = yes
+RGBLIGHT_ENABLE = no
 
 OLED_ENABLE = yes
 


### PR DESCRIPTION
## Summary
- DF(0)/DF(1) で Mac/Win 手動切替する8レイヤー構成を実装
- Navigation・F-keys を Mac/Win 共通化し、差分キーはカスタムキーコード (MY_LAUNCH/MY_RUN/MY_SS1/MY_SS2) で処理
- VIA 有効維持、RGBLIGHT は無効（フラッシュサイズ制約）
- ビルドサイズ: 25900/28672 (90%, 2772B空き)

## Test plan
- [x] Mac: DF切替、スクロールモード、マウスクリック動作確認済み
- [ ] Win: 全ショートカット疎通確認

Closes masatomix/task#598

🤖 Generated with [Claude Code](https://claude.com/claude-code)