### PR TITLE
feat(keyball44): Mac/Win共通化・DF永続化・GACS HRM適用 (#598, #655, #677)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
@@ -35,6 +35,27 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define TAP_CODE_DELAY 5
 
+// ---- Home Row Mods (GACS) 関連設定 ----
+//
+// TAPPING_TERM: Mod-Tap/Layer-Tap の「タップ」と「ホールド」を判別する閾値(ms)。
+//   この時間未満で離す → タップ（例: A）、以上押し続ける → ホールド（例: GUI）。
+//   QMK デフォルト: 200ms。Miryoku もデフォルトのまま。
+//   短すぎ → ホールド誤発動、長すぎ → モディファイア反応が遅い。
+#define TAPPING_TERM 200
+//
+// PERMISSIVE_HOLD: Mod-Tap キーを押している間に別キーを「押して離した」場合、
+//   TAPPING_TERM を待たず即座にホールド（Mod）扱いにする。
+//   有効 → Cmd+C 等のショートカットが素早く効く。
+//   無効 → 高速タイピング時の誤Mod発動が減る。
+//   まずは無効で始めて、ショートカットの反応が遅ければ有効化を検討。
+// #define PERMISSIVE_HOLD
+//
+// QUICK_TAP_TERM: 同じキーを連続タップした時の保護(ms)。
+//   前回タップから この時間以内に再度押す → 無条件でタップ扱い（ホールドにならない）。
+//   aaa... のキーリピートで GUI 等が暴発するのを防ぐ。
+//   0 にすると無効。
+// #define QUICK_TAP_TERM 120
+
 #define KEYBALL_CPI_DEFAULT 700 // マウス速度 (default: 700)
 #define KEYBALL_SCROLL_DIV_DEFAULT 6 // スクロール速度 (default: 6)
 

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -56,7 +56,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   // Layer 0: Base QWERTY (Mac)
   [L_MAC_BASE] = LAYOUT_universal(
     KC_TAB         , KC_Q       , KC_W     , KC_E     , KC_R      , KC_T ,                       KC_Y     , KC_U     , KC_I     , KC_O     , KC_P            , KC_EQL,
-    LCTL_T(KC_ESC) , KC_A       , KC_S     , KC_D     , LT(L_MOUSE,KC_F), KC_G ,                KC_H     , KC_J     , KC_K     ,KC_L, RCMD_T(KC_SCLN) , RCTL_T(KC_QUOT),
+    LCTL_T(KC_ESC) , LGUI_T(KC_A), LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), LT(L_MOUSE,KC_G) ,  KC_H     , RSFT_T(KC_J), RCTL_T(KC_K), RALT_T(KC_L), RGUI_T(KC_SCLN) , RCTL_T(KC_QUOT),
     KC_LSFT        , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , LT(L_MOUSE,KC_DOT)   , KC_SLSH         , RSFT_T(KC_BSLS),
                     KC_LALT     , KC_LGUI  , MO(L_MAC_SYM)    ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      LT(L_NAV,KC_BSPC),LT(L_ALT_MOD,KC_ENT), _______  ,  _______ , LT(L_MAC_SYM,KC_GRAVE)
   ),
@@ -64,7 +64,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   // Layer 1: Base QWERTY (Win) - Alt/Gui swap, RCTL_T(;), layer refs to Win layers
   [L_WIN_BASE] = LAYOUT_universal(
     KC_TAB         , KC_Q       , KC_W     , KC_E     , KC_R      , KC_T ,                       KC_Y     , KC_U     , KC_I     , KC_O     , KC_P            , KC_EQL,
-    LCTL_T(KC_ESC) , KC_A       , KC_S     , KC_D     , LT(L_MOUSE,KC_F), KC_G ,                KC_H     , KC_J     , KC_K     ,KC_L, RCTL_T(KC_SCLN) , RCTL_T(KC_QUOT),
+    LCTL_T(KC_ESC) , LGUI_T(KC_A), LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), LT(L_MOUSE,KC_G) ,  KC_H     , RSFT_T(KC_J), RCTL_T(KC_K), RALT_T(KC_L), RGUI_T(KC_SCLN) , RCTL_T(KC_QUOT),
     KC_LSFT        , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , LT(L_MOUSE,KC_DOT)   , KC_SLSH         , RSFT_T(KC_BSLS),
                     KC_LGUI     , KC_LALT  , MO(L_WIN_SYM)    ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      LT(L_NAV,KC_BSPC),LT(L_ALT_MOD,KC_ENT), _______  ,  _______ , LT(L_WIN_SYM,KC_GRAVE)
   ),

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -56,16 +56,16 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   // Layer 0: Base QWERTY (Mac)
   [L_MAC_BASE] = LAYOUT_universal(
     KC_TAB         , KC_Q       , KC_W     , KC_E     , KC_R      , KC_T ,                       KC_Y     , KC_U     , KC_I     , KC_O     , KC_P            , KC_EQL,
-    LCTL_T(KC_ESC) , LGUI_T(KC_A), LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), LT(L_MOUSE,KC_G) ,  KC_H     , RSFT_T(KC_J), RCTL_T(KC_K), RALT_T(KC_L), RGUI_T(KC_SCLN) , RCTL_T(KC_QUOT),
-    KC_LSFT        , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , LT(L_MOUSE,KC_DOT)   , KC_SLSH         , RSFT_T(KC_BSLS),
-                    KC_LALT     , KC_LGUI  , MO(L_MAC_SYM)    ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      LT(L_NAV,KC_BSPC),LT(L_ALT_MOD,KC_ENT), _______  ,  _______ , LT(L_MAC_SYM,KC_GRAVE)
+    KC_ESC         , LGUI_T(KC_A), LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), LT(L_MOUSE,KC_G) ,  KC_H     , RSFT_T(KC_J), RCTL_T(KC_K), RALT_T(KC_L), RGUI_T(KC_SCLN) , RCTL_T(KC_QUOT),
+    KC_NO          , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , KC_DOT   , LT(L_MOUSE,KC_SLSH), RSFT_T(KC_BSLS),
+                    KC_NO       , KC_NO    , MO(L_MAC_SYM)    ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      LT(L_NAV,KC_BSPC),LT(L_ALT_MOD,KC_ENT), _______  ,  _______ , LT(L_MAC_SYM,KC_GRAVE)
   ),
 
   // Layer 1: Base QWERTY (Win) - Alt/Gui swap, RCTL_T(;), layer refs to Win layers
   [L_WIN_BASE] = LAYOUT_universal(
     KC_TAB         , KC_Q       , KC_W     , KC_E     , KC_R      , KC_T ,                       KC_Y     , KC_U     , KC_I     , KC_O     , KC_P            , KC_EQL,
     LCTL_T(KC_ESC) , LGUI_T(KC_A), LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), LT(L_MOUSE,KC_G) ,  KC_H     , RSFT_T(KC_J), RCTL_T(KC_K), RALT_T(KC_L), RGUI_T(KC_SCLN) , RCTL_T(KC_QUOT),
-    KC_LSFT        , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , LT(L_MOUSE,KC_DOT)   , KC_SLSH         , RSFT_T(KC_BSLS),
+    KC_LSFT        , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , KC_DOT   , LT(L_MOUSE,KC_SLSH), RSFT_T(KC_BSLS),
                     KC_LGUI     , KC_LALT  , MO(L_WIN_SYM)    ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      LT(L_NAV,KC_BSPC),LT(L_ALT_MOD,KC_ENT), _______  ,  _______ , LT(L_WIN_SYM,KC_GRAVE)
   ),
 
@@ -88,8 +88,8 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   // Layer 4: Mouse (shared)
   [L_MOUSE] = LAYOUT_universal(
     _______  , _______  , _______  , _______  , _______  , _______  ,                             _______  , _______  , _______  , _______  , _______ , _______ ,
-    _______  , _______  , _______  , _______  , _______  , _______  ,                             _______  , KC_BTN1  , KC_BTN3  , KC_BTN2  , _______ , _______ ,
-    _______  , KC_BTN4  , KC_BTN5  , _______  , _______  , PRC_SW   ,                             _______  , _______  , _______  , _______  , _______  , _______ ,
+    _______  , _______  , _______  , _______  , _______  , _______  ,                             _______  , _______  , _______  , _______  , _______ , _______ ,
+    _______  , KC_BTN4  , KC_BTN5  , _______  , _______  , PRC_SW   ,                             _______  , KC_BTN1  , KC_BTN3  , KC_BTN2  , _______  , _______ ,
                _______  , _______  , _______  , KC_BTN1  , _______  ,                             _______  , _______  , _______  , _______  , _______
   ),
 

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -149,8 +149,16 @@ static inline bool is_win_mode(void) {
     return get_highest_layer(default_layer_state) == L_WIN_BASE;
 }
 
-// 切り替え処理
+// DF永続化: DF()キーコード押下時にEEPROMへ保存
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    // DF(layer) キーコードを検出して永続化
+    if (keycode >= QK_DEF_LAYER && keycode <= QK_DEF_LAYER_MAX) {
+        if (record->event.pressed) {
+            uint8_t layer = keycode & 0x1F;
+            eeconfig_update_default_layer((layer_state_t)1 << layer);
+        }
+    }
+
     switch (keycode) {
         #ifdef LAYER_LED_ENABLE
         case LAY_TOG: toggle_layer_led(record->event.pressed); return true;
@@ -215,8 +223,15 @@ void oledkit_render_info_user(void) {
 }
 #endif
 
+// DF永続化: 起動時にEEPROMからデフォルトレイヤーを復元
+void keyboard_post_init_user(void) {
+    if (eeconfig_is_enabled()) {
+        layer_state_t dl = eeconfig_read_default_layer();
+        if (dl) {
+            default_layer_set(dl);
+        }
+    }
 #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
-void pointing_device_init_user(void) {
     set_auto_mouse_enable(true);
-}
 #endif
+}


### PR DESCRIPTION
## Summary
- Mac/Win キーマップ共通化 DF切替方式 (#598)
- DF設定のEEPROM永続化 (#655)
- GACS Home Row Mods 適用 (#677)
- Phase4: HRM移行に伴うキーマップ整理（Layer0モディファイア廃止、マウスレイヤーキー移動、クリックキー位置変更）

## 変更内容
- L0/L1 ホーム行に GACS 順（GUI→Alt→Ctrl→Shift）の HRM を適用
- Mouse レイヤーキーを F→G に移動（Shift と干渉回避）
- Layer4 右手レイヤーキーを `.`→`/` 位置へ移動
- Layer4 クリックキーを J/K/L→M/,/. へ1段下げ（HRM 干渉回避）
- Layer0: ESC から Ctrl 除去、左 Shift/Opt/Cmd 廃止（GACS で代替）
- HRM 設定（TAPPING_TERM 200ms 等）を config.h に追加

## ビルド結果
- 25972/28672 (90%, 2700 bytes free)

## Test plan
- [x] ファームウェアビルド成功
- [x] 実機で動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)