### PR TITLE
feat(keyball44): TAPPING_TERM 230ms + QUICK_TAP_TERM 120ms (#690)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //   この時間未満で離す → タップ（例: A）、以上押し続ける → ホールド（例: GUI）。
 //   QMK デフォルト: 200ms。Miryoku もデフォルトのまま。
 //   短すぎ → ホールド誤発動、長すぎ → モディファイア反応が遅い。
-#define TAPPING_TERM 200
+#define TAPPING_TERM 230
 //
 // PERMISSIVE_HOLD: Mod-Tap キーを押している間に別キーを「押して離した」場合、
 //   TAPPING_TERM を待たず即座にホールド（Mod）扱いにする。
@@ -54,7 +54,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //   前回タップから この時間以内に再度押す → 無条件でタップ扱い（ホールドにならない）。
 //   aaa... のキーリピートで GUI 等が暴発するのを防ぐ。
 //   0 にすると無効。
-// #define QUICK_TAP_TERM 120
+#define QUICK_TAP_TERM 120
 
 #define KEYBALL_CPI_DEFAULT 700 // マウス速度 (default: 700)
 #define KEYBALL_SCROLL_DIV_DEFAULT 6 // スクロール速度 (default: 6)


### PR DESCRIPTION
## Summary

- GACS HRM の高速タイピング時（「se」等）に TAPPING_TERM(200ms) を超えて Alt+E として誤判定される問題を軽減
- `TAPPING_TERM` を 200ms → 230ms に変更
- `QUICK_TAP_TERM 120` を有効化（同キー連打時の Mod 暴発保護）
- `PERMISSIVE_HOLD` は無効のまま維持

## Test plan

- [x] ファームウェアビルド成功確認（25982/28672, 90%）
- [x] キーボードにフラッシュ
- [x] 高速タイピングで「se」「as」等の誤Mod判定が減ったことを確認
- [x] 意図的なショートカット（Cmd+C等）の反応が許容範囲であることを確認

Closes masatomix/task#690

🤖 Generated with [Claude Code](https://claude.com/claude-code)