### PR TITLE
fix(keyball44): TAPPING_TERM 230ms → 250ms に調整

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
@@ -41,7 +41,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //   この時間未満で離す → タップ（例: A）、以上押し続ける → ホールド（例: GUI）。
 //   QMK デフォルト: 200ms。Miryoku もデフォルトのまま。
 //   短すぎ → ホールド誤発動、長すぎ → モディファイア反応が遅い。
-#define TAPPING_TERM 230
+#define TAPPING_TERM 250
 //
 // PERMISSIVE_HOLD: Mod-Tap キーを押している間に別キーを「押して離した」場合、
 //   TAPPING_TERM を待たず即座にホールド（Mod）扱いにする。


### PR DESCRIPTION
## Summary

- 230ms でもまだ高速タイピング時の誤Mod判定が発生するため TAPPING_TERM を 250ms に引き上げ

## Test plan

- [x] ファームウェアビルド成功確認（25982/28672, 90%）
- [x] キーボードにフラッシュ
- [x] 誤Mod判定の改善確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)