### PR TITLE
feat(keyball44): RGBLIGHT + LAYER_LED 復活

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
@@ -65,7 +65,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define AUTO_MOUSE_TIME 400 // マウスが止まってから元のレイヤーに戻るまでの時間(ms)
 
 
-// #define LAYER_LED_ENABLE  // サイズ不足のため無効化
+#define LAYER_LED_ENABLE
 
 #define PRECISION_ENABLE // 有効化
 #define PRECISION_CPI 3  // 下げた時のCPI (1/100の値を指定。左記ならCPI 300)

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -20,6 +20,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "quantum.h"
 
+// Layer number definitions
+// Base layers (must be lower than shared/momentary layers)
+#define L_MAC_BASE  0
+#define L_WIN_BASE  1
+// Shared momentary layers
+#define L_NAV       2  // Navigation (Mac/Win shared)
+#define L_FKEYS     3  // F-keys (Mac/Win shared)
+#define L_MOUSE     4
+#define L_SYM       5  // Symbols/Numbers (Mac/Win shared)
+
 #ifdef LAYER_LED_ENABLE
 #include "layer_led.c"
 #endif
@@ -35,16 +45,6 @@ enum my_keyball_keycodes {
     MY_SS1,                       // スクショ1 (Mac: Cmd+Shift+4, Win: Alt+PrtSc)
     MY_SS2,                       // スクショ2 (Mac: Cmd+Shift+5, Win: PrtSc)
 };
-
-// Layer number definitions
-// Base layers (must be lower than shared/momentary layers)
-#define L_MAC_BASE  0
-#define L_WIN_BASE  1
-// Shared momentary layers
-#define L_NAV       2  // Navigation (Mac/Win shared)
-#define L_FKEYS     3  // F-keys (Mac/Win shared)
-#define L_MOUSE     4
-#define L_SYM       5  // Symbols/Numbers (Mac/Win shared)
 
 // clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/layer_led.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/layer_led.c
@@ -20,7 +20,7 @@ void change_layer_led_color(uint8_t layer_no) {
     uprintf("highest_layer_no: %u \n", get_highest_layer(layer_no));
 #endif
 
-    if (get_highest_layer(layer_no) != 3) {
+    if (get_highest_layer(layer_no) != L_MOUSE) {
         my_latest_val = rgblight_get_val();
         rgblight_sethsv(rgblight_get_hue(), rgblight_get_sat(), 0);
     } else {

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/rules.mk
@@ -1,4 +1,4 @@
-RGBLIGHT_ENABLE = no
+RGBLIGHT_ENABLE = yes
 
 OLED_ENABLE = yes
 


### PR DESCRIPTION
## Summary

- RGBLIGHT_ENABLE を yes に戻し LAYER_LED_ENABLE を復活
- layer_led.c のマウスレイヤー判定を 3 → L_MOUSE に修正
- レイヤー定義を #include より前に移動（コンパイル順序対応）
- ビルド: 28616/28672 (99%, 56 bytes free)

## Test plan

- [ ] キーボードにフラッシュ
- [ ] マウスレイヤー(Layer 4)でLEDが光ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)