### PR TITLE
feat(keyball44): Tap DanceでIME切替キー追加 (task#704)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -46,6 +46,14 @@ enum my_keyball_keycodes {
     MY_SS2,                       // スクショ2 (Mac: Cmd+Shift+5, Win: PrtSc)
 };
 
+// Tap Dance: 1タップ=LNG2(英数), ダブルタップ=LNG1(かな)
+enum {
+    TD_LNG = 0,
+};
+tap_dance_action_t tap_dance_actions[] = {
+    [TD_LNG] = ACTION_TAP_DANCE_DOUBLE(KC_LNG2, KC_LNG1),
+};
+
 // clang-format off
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   // Layer 0: Base QWERTY (Mac)
@@ -53,7 +61,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TAB         , KC_Q       , KC_W     , KC_E     , KC_R      , KC_T ,                       KC_Y     , KC_U     , KC_I     , KC_O     , KC_P            , KC_EQL,
     KC_ESC         , LGUI_T(KC_A), LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), LT(L_MOUSE,KC_G) ,  KC_H     , RSFT_T(KC_J), RCTL_T(KC_K), RALT_T(KC_L), RGUI_T(KC_SCLN) , RCTL_T(KC_QUOT),
     KC_NO          , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , KC_DOT   , LT(L_MOUSE,KC_SLSH), RSFT_T(KC_BSLS),
-                    KC_NO       , KC_NO    , MO(L_SYM)    ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      KC_BSPC,LT(L_NAV,KC_ENT), _______  ,  _______ , LT(L_SYM,KC_GRAVE)
+                    KC_NO       ,TD(TD_LNG), MO(L_SYM)    ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      KC_BSPC,LT(L_NAV,KC_ENT), _______  ,  _______ , LT(L_SYM,KC_GRAVE)
   ),
 
   // Layer 1: Base QWERTY (Win) - Alt/Gui swap, RCTL_T(;), layer refs to Win layers

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/rules.mk
@@ -7,3 +7,5 @@ VIA_ENABLE = yes
 EXTRAKEY_ENABLE = yes
 
 # CONSOLE_ENABLE = yes
+
+TAP_DANCE_ENABLE = yes


### PR DESCRIPTION
## Summary
- `TAP_DANCE_ENABLE = yes` を追加
- Mac親指行の位置4（左から2番目）に `TD(TD_LNG)` を配置
  - 1タップ = KC_LNG2（英数）
  - ダブルタップ = KC_LNG1（かな）
- ファームウェアサイズ: 25,312B (88%, 3,360B free)

## 背景
- KC_LNG1 が Sym レイヤー左下段にあり、アクセスしづらかった
- #30 (OLED無効化) で4,072B確保済みのため、Tap Dance (+712B) が利用可能に
- 関連: masatomix/task#704, masatomix/task#646

## Test plan
- [x] `make keyball/keyball44:masatomix` でビルド成功
- [x] フラッシュして1タップ=英数、ダブルタップ=かな の動作確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)