### PR TITLE
feat(keyball44): RGBLIGHT無効化 & OLED有効化 (#715)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
@@ -20,19 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
-#ifdef RGBLIGHT_ENABLE
-// #    define RGBLIGHT_EFFECT_BREATHING
-// #    define RGBLIGHT_EFFECT_RAINBOW_MOOD
-// #    define RGBLIGHT_EFFECT_RAINBOW_SWIRL
-// //#    define RGBLIGHT_EFFECT_SNAKE
-// #    define RGBLIGHT_EFFECT_KNIGHT
-// //#    define RGBLIGHT_EFFECT_CHRISTMAS
-// #    define RGBLIGHT_EFFECT_STATIC_GRADIENT
-// //#    define RGBLIGHT_EFFECT_RGB_TEST
-// //#    define RGBLIGHT_EFFECT_ALTERNATING
-// //#    define RGBLIGHT_EFFECT_TWINKLE
-#endif
-
 #define TAP_CODE_DELAY 5
 
 // ---- Home Row Mods (GACS) 関連設定 ----
@@ -65,8 +52,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define AUTO_MOUSE_TIME 400 // マウスが止まってから元のレイヤーに戻るまでの時間(ms)
 
 
-#define LAYER_LED_ENABLE
-
 #define PRECISION_ENABLE // 有効化
 #define PRECISION_CPI 3  // 下げた時のCPI (1/100の値を指定。左記ならCPI 300)
 
@@ -77,7 +62,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define KEYBALL_SCROLLSNAP_ENABLE 0
 
 
-// #define MOUSE_LED_COLOR HSV_TURQUOISE
-// #define MOUSE_LED_COLOR HSV_BLUE
-#define MOUSE_LED_COLOR HSV_AZURE
 

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/rules.mk
@@ -1,6 +1,6 @@
-RGBLIGHT_ENABLE = yes
+RGBLIGHT_ENABLE = no
 
-OLED_ENABLE = no
+OLED_ENABLE = yes
 
 VIA_ENABLE = yes
 


### PR DESCRIPTION
## Summary
- `RGBLIGHT_ENABLE = no` / `OLED_ENABLE = yes` に切り替え
- config.h から RGBLIGHT 関連設定を削除（RGBLIGHT_EFFECT群、LAYER_LED_ENABLE、MOUSE_LED_COLOR）
- キーマップ上の RGB_* キーはそのまま残す（RGBLIGHT無効時は何も起こらない）
- ファームウェアサイズ: 25,312/28,672 bytes (88%)

Closes masatomix/task#715

## Test plan
- [ ] OLED にキー情報・レイヤー情報が表示される
- [ ] RGBLIGHT LED が点灯しないこと
- [ ] 全レイヤーの動作に影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)