### PR TITLE
feat(keyball44): PERMISSIVE_HOLD有効化 (#719)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
@@ -35,7 +35,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //   有効 → Cmd+C 等のショートカットが素早く効く。
 //   無効 → 高速タイピング時の誤Mod発動が減る。
 //   まずは無効で始めて、ショートカットの反応が遅ければ有効化を検討。
-// #define PERMISSIVE_HOLD
+#define PERMISSIVE_HOLD
 //
 // QUICK_TAP_TERM: 同じキーを連続タップした時の保護(ms)。
 //   前回タップから この時間以内に再度押す → 無条件でタップ扱い（ホールドにならない）。


### PR DESCRIPTION
## Summary
- config.h の `PERMISSIVE_HOLD` を有効化
- Shift同時押し（大文字入力等）で `fm` のような誤爆を解消
- ファームウェアサイズ: 25,230/28,672 bytes (87%)

Closes masatomix/task#719

## Test plan
- [ ] 大文字入力（F+M → Shift+M）が素早い操作でも正しく発動する
- [ ] 通常タイピングで意図しないMod発動が許容範囲内であること
- [ ] 問題があれば revert で即座に戻せること

🤖 Generated with [Claude Code](https://claude.com/claude-code)