### PR TITLE
feat(keyball44): 左親指右端キーをLNG2→Tabに変更 (#720)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -81,7 +81,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TAB         , KC_Q       , KC_W     , KC_E     , KC_R      , KC_T ,                       KC_Y     , KC_U     , KC_I     , KC_O     , KC_P            , KC_EQL,
     KC_ESC         , LGUI_T(KC_A), LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), LT(L_MOUSE,KC_G) ,  KC_H     , RSFT_T(KC_J), RCTL_T(KC_K), RALT_T(KC_L), RGUI_T(KC_SCLN) , KC_QUOT,
     KC_NO          , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , KC_DOT   , LT(L_MOUSE,KC_SLSH), KC_BSLS,
-                    KC_NO       ,TD(TD_LNG), MO(L_SYM)    ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      KC_BSPC,LT(L_NAV,KC_ENT), _______  ,  _______ , LT(L_SYM,KC_GRAVE)
+                    KC_NO       ,TD(TD_LNG), MO(L_SYM)    ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_TAB),      KC_BSPC,LT(L_NAV,KC_ENT), _______  ,  _______ , LT(L_SYM,KC_GRAVE)
   ),
 
   // Layer 1: Base QWERTY (Win) - Alt/Gui swap, RCTL_T(;), layer refs to Win layers


### PR DESCRIPTION
## Summary
- Layer 0 左親指右端: `LT(L_FKEYS,KC_LNG2)` → `LT(L_FKEYS,KC_TAB)`
- IME切替は TD(TD_LNG) で対応済みのため LNG2 は冗長
- ファームウェアサイズ: 26,436/28,672 bytes (92%) 変化なし

Closes masatomix/task#720

## Test plan
- [ ] タップで Tab が入力される
- [ ] ホールドで F-keys レイヤーに切り替わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)