### PR TITLE
feat(keyball44): Shift+BS→Del Mod-Morph & Tab左親指移動 (#723)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -87,7 +87,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TAB         , KC_Q       , KC_W     , KC_E     , KC_R      , KC_T ,                       KC_Y     , KC_U     , KC_I     , KC_O     , KC_P            , KC_EQL,
     KC_ESC         , LGUI_T(KC_A), LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), LT(L_MOUSE,KC_G) ,  KC_H     , RSFT_T(KC_J), RCTL_T(KC_K), RALT_T(KC_L), RGUI_T(KC_SCLN) , KC_QUOT,
     KC_NO          , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , KC_DOT   , LT(L_MOUSE,KC_SLSH), KC_BSLS,
-                    KC_NO       ,TD(TD_LNG), MO(L_SYM)    ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_TAB),      KC_BSPC,LT(L_NAV,KC_ENT), _______  ,  _______ , LT(L_SYM,KC_GRAVE)
+                    KC_TAB      ,TD(TD_LNG), MO(L_SYM)    ,LT(L_NAV,KC_SPC),MO(L_FKEYS)       ,      KC_BSPC,LT(L_NAV,KC_ENT), _______  ,  _______ , LT(L_SYM,KC_GRAVE)
   ),
 
   // Layer 1: Base QWERTY (Win) - Alt/Gui swap, RCTL_T(;), layer refs to Win layers
@@ -178,6 +178,28 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         #ifdef PRECISION_ENABLE
         case PRC_SW:  precision_switch(record->event.pressed); return false;
         #endif
+
+        // Mod-Morph: Shift+Backspace → Delete
+        case KC_BSPC: {
+            static bool del_registered = false;
+            if (record->event.pressed) {
+                uint8_t mods = get_mods();
+                if (mods & MOD_MASK_SHIFT) {
+                    del_mods(MOD_MASK_SHIFT);
+                    register_code(KC_DEL);
+                    del_registered = true;
+                    set_mods(mods);
+                    return false;
+                }
+            } else {
+                if (del_registered) {
+                    unregister_code(KC_DEL);
+                    del_registered = false;
+                    return false;
+                }
+            }
+            return true;
+        }
 
         default: break;
     }


### PR DESCRIPTION
## Summary
- Shift+Backspace で Delete を送信する Mod-Morph を `process_record_user` で実装
- Mac Base レイヤーの左親指一番左キー（KC_NO → KC_TAB）に Tab を移動
- 旧 Tab 位置を `LT(L_FKEYS,KC_TAB)` → `MO(L_FKEYS)` に変更

## Details
- Key Override ではなく `process_record_user` 内で実装（Flash 軽量: 92%, 2086 bytes free）
- Home Row Mods の LSFT_T/RSFT_T からの Shift にも対応

## Test plan
- [ ] Backspace 単押し → Backspace が送信される
- [ ] Shift + Backspace → Delete が送信される
- [ ] 左親指一番左キーで Tab が送信される
- [ ] 右親指の MO(L_FKEYS) ホールドで F-keys レイヤーに切替
- [ ] Mac / Win 両方で動作確認
- [ ] ビルド OK（92%, 2086 bytes free）

Closes masatomix/task#723

🤖 Generated with [Claude Code](https://claude.com/claude-code)