### PR TITLE
feat(keyball44): IME切替をTap Dance→Mod-Morphに変更 (#729)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -46,8 +46,7 @@ enum my_keyball_keycodes {
 
 // Tap Dance definitions
 enum {
-    TD_LNG = 0,  // 1タップ=LNG2(英数), ダブルタップ=LNG1(かな)
-    TD_SS1,      // 1タップ=Mac スクショ(Cmd+Shift+4), ダブルタップ=Win スクショ(Alt+PrtSc)
+    TD_SS1 = 0,  // 1タップ=Mac スクショ(Cmd+Shift+4), ダブルタップ=Win スクショ(Alt+PrtSc)
     TD_SS2,      // 1タップ=Mac スクショ(Cmd+Shift+5), ダブルタップ=Win スクショ(PrtSc)
     TD_PRN,      // 1タップ=( ダブルタップ=)
     TD_CBR,      // 1タップ={ ダブルタップ=}
@@ -72,7 +71,6 @@ void td_ss2_finished(tap_dance_state_t *state, void *user_data) {
 }
 
 tap_dance_action_t tap_dance_actions[] = {
-    [TD_LNG] = ACTION_TAP_DANCE_DOUBLE(KC_LNG2, KC_LNG1),
     [TD_SS1] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, td_ss1_finished, NULL),
     [TD_SS2] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, td_ss2_finished, NULL),
     [TD_PRN] = ACTION_TAP_DANCE_DOUBLE(S(KC_9), S(KC_0)),         // ( )
@@ -87,7 +85,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_TAB         , KC_Q       , KC_W     , KC_E     , KC_R      , KC_T ,                       KC_Y     , KC_U     , KC_I     , KC_O     , KC_P            , KC_EQL,
     KC_ESC         , LGUI_T(KC_A), LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), LT(L_MOUSE,KC_G) ,  KC_H     , RSFT_T(KC_J), RCTL_T(KC_K), RALT_T(KC_L), RGUI_T(KC_SCLN) , KC_QUOT,
     KC_NO          , KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , KC_DOT   , LT(L_MOUSE,KC_SLSH), KC_BSLS,
-                    KC_TAB      ,TD(TD_LNG), MO(L_SYM)    ,LT(L_NAV,KC_SPC),MO(L_FKEYS)       ,      KC_BSPC,LT(L_NAV,KC_ENT), _______  ,  _______ , LT(L_SYM,KC_GRAVE)
+                    KC_TAB      ,KC_LNG2   , MO(L_SYM)    ,LT(L_NAV,KC_SPC),MO(L_FKEYS)       ,      KC_BSPC,LT(L_NAV,KC_ENT), _______  ,  _______ , LT(L_SYM,KC_GRAVE)
   ),
 
   // Layer 1: Base QWERTY (Win) - Alt/Gui swap, RCTL_T(;), layer refs to Win layers
@@ -178,6 +176,28 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         #ifdef PRECISION_ENABLE
         case PRC_SW:  precision_switch(record->event.pressed); return false;
         #endif
+
+        // Mod-Morph: Shift+LNG2 → LNG1
+        case KC_LNG2: {
+            static bool lng1_registered = false;
+            if (record->event.pressed) {
+                uint8_t mods = get_mods();
+                if (mods & MOD_MASK_SHIFT) {
+                    del_mods(MOD_MASK_SHIFT);
+                    register_code(KC_LNG1);
+                    lng1_registered = true;
+                    set_mods(mods);
+                    return false;
+                }
+            } else {
+                if (lng1_registered) {
+                    unregister_code(KC_LNG1);
+                    lng1_registered = false;
+                    return false;
+                }
+            }
+            return true;
+        }
 
         // Mod-Morph: Shift+Backspace → Delete
         case KC_BSPC: {


### PR DESCRIPTION
## Summary
- TD_LNG（タップ=英数、ダブルタップ=かな）を廃止
- Mod-Morph 方式に変更: タップ=LNG2(英数)、Shift+タップ=LNG1(かな)
- TAPPING_TERM 待ちがなくなり即座に発動

## Test plan
- [x] タップで英数（LNG2）が送信される
- [x] Shift + タップでかな（LNG1）が送信される
- [x] 即座に発動する（待ちなし）
- [x] ビルド OK（92%, 2044 bytes free）

Closes masatomix/task#729

🤖 Generated with [Claude Code](https://claude.com/claude-code)