### PR TITLE
feat(keyball44): GUIキー per-key tapping term (#736)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -237,6 +237,17 @@ void oledkit_render_info_user(void) {
 }
 #endif
 
+// Per-key tapping term: GUI キーは誤爆しやすいため長めに設定 (#736)
+uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case LGUI_T(KC_A):
+        case RGUI_T(KC_SCLN):
+            return 300;
+        default:
+            return TAPPING_TERM;
+    }
+}
+
 // DF永続化: 起動時にEEPROMからデフォルトレイヤーを復元
 void keyboard_post_init_user(void) {
     if (eeconfig_is_enabled()) {


### PR DESCRIPTION
## Summary
- LGUI_T(A) / RGUI_T(;) の TAPPING_TERM を 300ms に延長（他キーは 250ms）
- タイピング中の GUI（Cmd/Win）誤発動を防止

## Test plan
- [ ] A を素早くタイプして GUI が誤発動しないこと
- [ ] Cmd+A / Cmd+C 等のショートカットが正常に使えること
- [ ] ビルド OK（92%, 2044 bytes free）

Closes masatomix/task#736

🤖 Generated with [Claude Code](https://claude.com/claude-code)