### PR TITLE
feat(keyball44): Symレイヤー 5列移行準備 (#738)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -51,6 +51,7 @@ enum {
     TD_PRN,      // 1タップ=( ダブルタップ=)
     TD_CBR,      // 1タップ={ ダブルタップ=}
     TD_BRC,      // 1タップ=[ ダブルタップ=]
+    TD_QUO,      // 1タップ=' ダブルタップ=" (#738 5列移行準備)
 };
 
 // Tap Dance スクショ用コールバック
@@ -76,6 +77,7 @@ tap_dance_action_t tap_dance_actions[] = {
     [TD_PRN] = ACTION_TAP_DANCE_DOUBLE(S(KC_9), S(KC_0)),         // ( )
     [TD_CBR] = ACTION_TAP_DANCE_DOUBLE(S(KC_LBRC), S(KC_RBRC)),   // { }
     [TD_BRC] = ACTION_TAP_DANCE_DOUBLE(KC_LBRC, KC_RBRC),         // [ ]
+    [TD_QUO] = ACTION_TAP_DANCE_DOUBLE(KC_QUOT, S(KC_QUOT)),     // ' "
 };
 
 // clang-format off
@@ -124,7 +126,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   [L_SYM] = LAYOUT_universal(
     S(KC_GRAVE)         , S(KC_1)  , S(KC_2)  , S(KC_3)   , S(KC_4) , S(KC_5) ,                   S(KC_6)  , S(KC_7)   , S(KC_8) , S(KC_9)  , S(KC_0)  , S(KC_MINS),
     LCTL_T(KC_GRAVE)    , LGUI_T(KC_1), LALT_T(KC_2), LCTL_T(KC_3), LSFT_T(KC_4), KC_5,          KC_6     , RSFT_T(KC_7), RCTL_T(KC_8), RALT_T(KC_9), RGUI_T(KC_0) , RCTL_T(KC_MINS),
-    KC_LNG1  , KC_BTN4  , KC_BTN5  , TD(TD_PRN), TD(TD_CBR), TD(TD_BRC),                           KC_RBRC  , S(KC_RBRC), _______ , _______  , _______  , _______ ,
+    KC_LNG1  , KC_BSLS  ,TD(TD_QUO), TD(TD_PRN), TD(TD_CBR), TD(TD_BRC),                           KC_EQL   , KC_MINS   , _______ , _______  , _______  , _______ ,
                _______  , _______  , _______  ,  _______  , _______ ,                             _______  , _______   , _______ , _______  , _______
   ),
 };


### PR DESCRIPTION
## Summary
- Sym左row2: BTN4→`\`(`|`), BTN5→TD `'`/`"` (新規 TD_QUO)
- Sym右row2: `]`→`=`(`+`), `}`→`-`(`_`)
- 5列配列移行時に外側列を削除しても記号キーにアクセスできるよう準備
- 外側列は現状維持（併用期間）

## Test plan
- [ ] Sym + \ で backslash、Shift+\ で pipe
- [ ] Sym + TD_QUO: タップ=' ダブルタップ="
- [ ] Sym + = で equal、Shift+= で plus
- [ ] Sym + - で minus、Shift+- で underscore
- [ ] 外側列の既存キーも引き続き動作
- [ ] ビルド OK（92%, 2042 bytes free）

Related: masatomix/task#738

🤖 Generated with [Claude Code](https://claude.com/claude-code)