### PR TITLE
feat(keyball44): Shift(F/J)のみ per-key PERMISSIVE_HOLD 有効化 (#744)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -256,6 +256,17 @@ uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
     }
 }
 
+// Per-key PERMISSIVE_HOLD: Shift のみ即ホールド判定で大文字入力を高速化 (#744)
+bool get_permissive_hold(uint16_t keycode, keyrecord_t *record) {
+    switch (keycode) {
+        case LSFT_T(KC_F):
+        case RSFT_T(KC_J):
+            return true;
+        default:
+            return false;
+    }
+}
+
 // DF永続化: 起動時にEEPROMからデフォルトレイヤーを復元
 void keyboard_post_init_user(void) {
     if (eeconfig_is_enabled()) {


### PR DESCRIPTION
## Summary
- `get_permissive_hold()` を追加し、LSFT_T(KC_F) / RSFT_T(KC_J) のみ PERMISSIVE_HOLD を有効化
- GUI/Ctrl/Alt は従来通り無効（#719 での GUI 誤爆を回避）
- ファームサイズ変化なし（99%, 258 bytes free）

## Test plan
- [x] ビルド成功
- [ ] 実機で Shift+文字の大文字入力が即座に反応することを確認
- [ ] GUI(A/;)、Ctrl(D/K)、Alt(S/L) が誤爆しないことを確認

Closes masatomix/task#744

🤖 Generated with [Claude Code](https://claude.com/claude-code)