### PR TITLE
fix(keyball44): デッドコード・未使用変数削除 (#713)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -18,8 +18,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include QMK_KEYBOARD_H
 
-#include "quantum.h"
-
 // Layer number definitions
 // Base layers (must be lower than shared/momentary layers)
 #define L_MAC_BASE  0
@@ -161,11 +159,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     return state;
 }
 
-
-// OS判定ヘルパー
-static inline bool is_win_mode(void) {
-    return get_highest_layer(default_layer_state) == L_WIN_BASE;
-}
 
 // DF永続化: DF()キーコード押下時にEEPROMへ保存
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/layer_led.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/layer_led.c
@@ -2,8 +2,6 @@
 
 #include QMK_KEYBOARD_H
 
-static const uint8_t my_layer_colors[] = {234, 17,170, 85}; // ピンク、黄、青、緑
-
 static uint8_t my_latest_val = 0;
 static uint8_t my_latest_hue = 0;
 // static bool    layer_led     = false;
@@ -24,8 +22,6 @@ void change_layer_led_color(uint8_t layer_no) {
         my_latest_val = rgblight_get_val();
         rgblight_sethsv(rgblight_get_hue(), rgblight_get_sat(), 0);
     } else {
-        // rgblight_sethsv(my_layer_colors[layer_no-1], rgblight_get_sat(), my_latest_val);
-
 #ifdef MOUSE_LED_COLOR
         rgblight_sethsv(MOUSE_LED_COLOR);
 #else

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/precision.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/precision.c
@@ -2,18 +2,13 @@
 
 #include QMK_KEYBOARD_H
 
-static const uint16_t PROGMEM down_cpi = PRECISION_CPI;
-
 static uint16_t latest_cpi = 1;
-static bool     cpi_state  = false;
 
 // キー押下中だけ切り替え
 void precision_switch(bool pressed) {
     if (pressed) {
-        if(!cpi_state) {
-            latest_cpi = keyball_get_cpi();
-        }
-        keyball_set_cpi(down_cpi);
+        latest_cpi = keyball_get_cpi();
+        keyball_set_cpi(PRECISION_CPI);
     } else {
         keyball_set_cpi(latest_cpi);
     }


### PR DESCRIPTION
## Summary

- `is_win_mode()` デッド関数削除（keymap.c）
- `precision.c`: 未使用 `cpi_state` ガード変数削除、`PROGMEM down_cpi` 廃止→直接 `PRECISION_CPI` マクロ使用
- `#include "quantum.h"` 重複インクルード削除（keymap.c）
- `my_layer_colors[]` 未使用配列・コメントアウト済み参照削除（layer_led.c）

## Test plan

- [x] ビルド通過確認（28,414/28,672 bytes, 99%）
- [ ] 実機で Precision モード動作確認
- [ ] 実機で Layer LED 動作確認

Closes masatomix/task#713

🤖 Generated with [Claude Code](https://claude.com/claude-code)