### PR TITLE
fix(keyball44): Precision CPI復元ガード追加 (task#745)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -140,6 +140,13 @@ layer_state_t layer_state_set_user(layer_state_t state) {
     // Auto enable scroll mode when the highest layer is Symbols
     keyball_set_scroll_mode(get_highest_layer(state) == L_SYM);
 
+    // Precision CPI復元ガード: L_MOUSEを抜けたらCPIを戻す (#745)
+    #ifdef PRECISION_ENABLE
+    if (!layer_state_cmp(state, L_MOUSE)) {
+        precision_restore_cpi();
+    }
+    #endif
+
     #ifdef LAYER_LED_ENABLE
     change_layer_led_color(state);
     #endif

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/precision.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/precision.c
@@ -3,13 +3,26 @@
 #include QMK_KEYBOARD_H
 
 static uint16_t latest_cpi = 1;
+static bool     cpi_state  = false;
 
 // キー押下中だけ切り替え
 void precision_switch(bool pressed) {
     if (pressed) {
-        latest_cpi = keyball_get_cpi();
+        if (!cpi_state) {
+            latest_cpi = keyball_get_cpi();
+        }
+        cpi_state = true;
         keyball_set_cpi(PRECISION_CPI);
     } else {
+        cpi_state = false;
+        keyball_set_cpi(latest_cpi);
+    }
+}
+
+// レイヤー離脱時のCPI復元ガード (#745)
+void precision_restore_cpi(void) {
+    if (cpi_state) {
+        cpi_state = false;
         keyball_set_cpi(latest_cpi);
     }
 }


### PR DESCRIPTION
## Summary
- PRC_SWを押したままL_MOUSEレイヤーが解除されるとCPIが低速のまま戻らないバグを修正
- `layer_state_set_user`にガードを追加し、L_MOUSE離脱時に`precision_restore_cpi()`で元のCPIに復元
- `precision.c`の`cpi_state`フラグを正しく管理するように修正

Closes masatomix/task#745

## Test plan
- [ ] ビルド通過確認済み（28460/28672, 99%）
- [ ] 通常のPRC_SW押下→離しで正常にCPI復元されること
- [ ] PRC_SW押下中にL_MOUSEレイヤーが解除された場合もCPI復元されること
- [ ] auto mouseレイヤー経由でも同様に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)