### PR TITLE
feat(keyball44): D+F Combo→Tab追加 (#749)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -37,10 +37,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "precision.c"
 #endif
 
-// Combo: J+K → Esc (#738 5列移行準備)
+// Combo: J+K → Esc (#738), D+F → Tab (#749) 5列移行準備
 const uint16_t PROGMEM jk_combo[] = {RSFT_T(KC_J), RCTL_T(KC_K), COMBO_END};
+const uint16_t PROGMEM df_combo[] = {LCTL_T(KC_D), LSFT_T(KC_F), COMBO_END};
 combo_t key_combos[] = {
     COMBO(jk_combo, KC_ESC),
+    COMBO(df_combo, KC_TAB),
 };
 
 enum my_keyball_keycodes {


### PR DESCRIPTION
## Summary

- D+F 同時押しで Tab を発動する Combo を追加
- 既存の J+K → Esc Combo と同じ手法（Mod-Tap キー同士の Combo）

## Test plan

- [x] ビルド通過確認（28,528/28,672 bytes, 99%）
- [ ] 実機で D+F → Tab 動作確認
- [ ] 既存 J+K → Esc に影響がないこと確認
- [ ] D, F 単体タップ・ホールドに影響がないこと確認

Closes masatomix/task#749

🤖 Generated with [Claude Code](https://claude.com/claude-code)