### PR TITLE
feat(keyball44): Shift(F/J)をHOLD_ON_OTHER_KEY_PRESSに変更 (masatomix/task#756)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -258,8 +258,11 @@ uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
     }
 }
 
-// Per-key PERMISSIVE_HOLD: Shift のみ即ホールド判定で大文字入力を高速化 (#744)
-bool get_permissive_hold(uint16_t keycode, keyrecord_t *record) {
+// Per-key HOLD_ON_OTHER_KEY_PRESS: Shift(F/J) のみ、別キーが押された瞬間に即ホールド判定 (#756)
+// PERMISSIVE_HOLD (#744) より早く Shift が確定するため、Mod キーを先に離してしまうケースでも
+// 大文字入力 (例: F = Shift+f) が確実に発動する。
+// HOLD_ON_OTHER_KEY_PRESS は PERMISSIVE_HOLD の上位互換のため、F/J については PERMISSIVE_HOLD は不要。
+bool get_hold_on_other_key_press(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case LSFT_T(KC_F):
         case RSFT_T(KC_J):


### PR DESCRIPTION
## Summary
- PERMISSIVE_HOLD (#744 / PR #46) を Shift(F/J) のみ HOLD_ON_OTHER_KEY_PRESS に置き換え
- `get_permissive_hold` → `get_hold_on_other_key_press` にリネーム
- F/J 以外への影響なし

## 背景

Shift+F (大文字F) を入力しようとした際、Mod キー(J)を先に離してしまうと PERMISSIVE_HOLD は発動せず、結果的に `jf` のように両方タップとして登録される事象が発生していた。

HOLD_ON_OTHER_KEY_PRESS は「次のキーが**押された瞬間**にホールド判定」するため、PERMISSIVE_HOLD（次のキーが離されたとき判定）より早く Shift が確定する。両者は上位/下位互換の関係なので、F/J には HOLD_ON_OTHER_KEY_PRESS のみで十分。

## 想定される副作用
- 逆手のロール入力（例: `fj`, `jf`）で Shift が誤発動する可能性
- ただし F/J は反対の手なので、同じ手の内側ロール（`fr`, `fg`, `kl` 等）は影響なし

## ビルド確認
- ✅ ローカルビルド成功
- **Flash: 28528/28672 bytes (99%, 144 bytes free)**
- ⚠ #744 時点の 258 bytes free から **114 bytes 減少**（`get_hold_on_other_key_press` フック追加分）

## Test plan
- [x] ローカルビルド成功
- [ ] 実機で大文字 F (Shift+F)、J (Shift+J) が `jf` 等にならず確実に入力できる
- [ ] 通常の小文字 f/j のタップが Shift 化しない

Closes masatomix/task#756

🤖 Generated with [Claude Code](https://claude.com/claude-code)