### PR TITLE
feat(keyball44): Shift(F/J) tap-hold判定OFF + TAPPING_TERM 150ms化 (masatomix/task#757)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -258,7 +258,7 @@ uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
             return 300;
         case LSFT_T(KC_F):
         case RSFT_T(KC_J):
-            return 150;
+            return 100;
         default:
             return TAPPING_TERM;
     }

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -247,25 +247,20 @@ void oledkit_render_info_user(void) {
 }
 #endif
 
-// Per-key tapping term: GUI キーは誤爆しやすいため長めに設定 (#736)
+// Per-key tapping term:
+// - GUI(A/;) は誤爆しやすいため長め (#736)
+// - Shift(F/J) は大文字入力時の誤入力対策で短め (#757)
+//   ※ #744 PERMISSIVE_HOLD per-key は撤回、TAPPING_TERM 短縮で対応
 uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case LGUI_T(KC_A):
         case RGUI_T(KC_SCLN):
             return 300;
-        default:
-            return TAPPING_TERM;
-    }
-}
-
-// Per-key PERMISSIVE_HOLD: Shift のみ即ホールド判定で大文字入力を高速化 (#744)
-bool get_permissive_hold(uint16_t keycode, keyrecord_t *record) {
-    switch (keycode) {
         case LSFT_T(KC_F):
         case RSFT_T(KC_J):
-            return true;
+            return 150;
         default:
-            return false;
+            return TAPPING_TERM;
     }
 }
 


### PR DESCRIPTION
## Summary
- \`get_permissive_hold\` 関数を削除（#744 を撤回）
- \`get_tapping_term\` に F/J = 150ms を追加
- 大文字 F/J 入力時の \`jf\` 化等の誤入力対策

## 背景

- #744 PERMISSIVE_HOLD per-key、#756 HOLD_ON_OTHER_KEY_PRESS per-key のいずれも実機検証で体感効果が得られなかった
- 判定アルゴリズム変更ではなく、F/J の TAPPING_TERM 自体を短縮（250ms → 150ms）する直接的アプローチに変更

## 変更内容

\`\`\`c
// Before
uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
    switch (keycode) {
        case LGUI_T(KC_A):
        case RGUI_T(KC_SCLN):
            return 300;
        default:
            return TAPPING_TERM;
    }
}
bool get_permissive_hold(uint16_t keycode, keyrecord_t *record) { ... }

// After
uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
    switch (keycode) {
        case LGUI_T(KC_A):
        case RGUI_T(KC_SCLN):
            return 300;
        case LSFT_T(KC_F):
        case RSFT_T(KC_J):
            return 150;
        default:
            return TAPPING_TERM;
    }
}
// get_permissive_hold は削除
\`\`\`

## 想定される副作用
- F/J を素早くタップした際に Shift と認識される可能性
- \"fish\", \"jump\" 等の語頭で誤発動の可能性（150ms はかなり短いので通常タイピングでは問題なさそう）

## ビルド確認
- ✅ ローカルビルド成功
- **Flash: 28528/28672 bytes (99%, 144 bytes free)** — 変化なし

## Test plan
- [x] ローカルビルド成功
- [ ] 大文字 F (Shift+F)、J (Shift+J) が \`jf\` 等にならず確実に入力できる
- [ ] 通常の小文字 f/j のタップが Shift 化しない（fish, jump 等が打てる）

Closes masatomix/task#757

🤖 Generated with [Claude Code](https://claude.com/claude-code)