### PR TITLE
fix(keyball44): スクロールスナップ初期値をFREEに (masatomix/task#761)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -280,4 +280,6 @@ void keyboard_post_init_user(void) {
 #ifdef POINTING_DEVICE_AUTO_MOUSE_ENABLE
     set_auto_mouse_enable(true);
 #endif
+    // スクロールスナップのデフォルトを FREE に設定（縦横両方動くように） (#761)
+    keyball_set_scrollsnap_mode(KEYBALL_SCROLLSNAP_MODE_FREE);
 }


### PR DESCRIPTION
Closes masatomix/task#761

## Summary
- `keyboard_post_init_user` で `keyball_set_scrollsnap_mode(KEYBALL_SCROLLSNAP_MODE_FREE)` 呼出
- #748 で SCROLLSNAP=2 有効化後、デフォルト VERTICAL で横スクロール不可だったのを修正

## ビルド
28246/28672 bytes (98%, 426 bytes free)

🤖 Generated with [Claude Code](https://claude.com/claude-code)