### PR TITLE
feat(keyball44): F/J Shift TAPPING_TERM 70ms (task#780)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
@@ -63,3 +63,4 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
 
+

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -205,12 +205,15 @@ void oledkit_render_info_user(void) {
 }
 #endif
 
-// Per-key tapping term: GUI キーは誤爆しやすいため長めに設定 (#736)
+// Per-key tapping term (#736, #780)
 uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
         case LGUI_T(KC_A):
         case RGUI_T(KC_SCLN):
             return 300;
+        case LSFT_T(KC_F):  // #780 切り分け: Shift判定高速化
+        case RSFT_T(KC_J):
+            return 70;
         default:
             return TAPPING_TERM;
     }


### PR DESCRIPTION
## Summary
- F/J の per-key TAPPING_TERM を 250ms → 70ms に短縮
- Shift+F で「f・」になる問題を緩和（完全解消ではなくホールド時は70ms待ちが残る）
- 急ぎの Shift は親指 LShift (#774) を使う運用

Refs masatomix/task#780