### PR TITLE
fix(keyball44): PER_KEY マクロ有効化 & F/J TAPPING_TERM 170ms (task#780)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/config.h
@@ -29,6 +29,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //   QMK デフォルト: 200ms。Miryoku もデフォルトのまま。
 //   短すぎ → ホールド誤発動、長すぎ → モディファイア反応が遅い。
 #define TAPPING_TERM 250
+#define TAPPING_TERM_PER_KEY       // get_tapping_term() 有効化 (#736 GUI 300ms, #780 F/J 70ms)
+#define PERMISSIVE_HOLD_PER_KEY    // get_permissive_hold() 有効化 (#744 F/J のみ)
 //
 // PERMISSIVE_HOLD: Mod-Tap キーを押している間に別キーを「押して離した」場合、
 //   TAPPING_TERM を待たず即座にホールド（Mod）扱いにする。

--- a/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball44/keymaps/masatomix/keymap.c
@@ -211,9 +211,9 @@ uint16_t get_tapping_term(uint16_t keycode, keyrecord_t *record) {
         case LGUI_T(KC_A):
         case RGUI_T(KC_SCLN):
             return 300;
-        case LSFT_T(KC_F):  // #780 切り分け: Shift判定高速化
+        case LSFT_T(KC_F):  // #780 Shift判定高速化
         case RSFT_T(KC_J):
-            return 70;
+            return 170;
         default:
             return TAPPING_TERM;
     }


### PR DESCRIPTION
## Summary
### 根本原因
\`TAPPING_TERM_PER_KEY\` / \`PERMISSIVE_HOLD_PER_KEY\` マクロが config.h で未定義のため、以下が**長期間すべて無効**になっていた:
- #736 GUI(A/;) 300ms (半年以上無効)
- #744 F/J per-key PERMISSIVE_HOLD
- #780 (PR#57) F/J TAPPING_TERM 70ms

### 修正
- config.h に \`TAPPING_TERM_PER_KEY\` / \`PERMISSIVE_HOLD_PER_KEY\` を追加
- F/J TAPPING_TERM: 70ms → 170ms（実機テストで決定）

### 検証方法
- debug hex で F/J TAPPING_TERM を 5000ms に設定 → 5 秒ホールドで Shift 判定を確認
- これにより per-key 関数が正しく呼ばれることを実証

ビルドサイズ: 28274/28672 (98%, 398 bytes free)

Refs masatomix/task#780