### PR TITLE
fix(keyball39): 右親指外側キーを R31→R30 に修正 (task#803)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/keymap.c
@@ -94,7 +94,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_Q       , KC_W     , KC_E     , KC_R      , KC_T ,                       KC_Y     , KC_U     , KC_I     , KC_O     , KC_P            ,
     LGUI_T(KC_A), LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), LT(L_MOUSE,KC_G) ,  KC_H     , RSFT_T(KC_J), RCTL_T(KC_K), RALT_T(KC_L), RGUI_T(KC_SCLN) ,
     KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , KC_DOT   , LT(L_MOUSE,KC_SLSH),
-    KC_NO      , KC_LSFT  ,KC_LNG1  , MO(L_SYM) ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      KC_BSPC,LT(L_NAV,KC_ENT), _______  ,  _______ , LT(L_SYM,KC_GRAVE), KC_NO
+    KC_NO      , KC_LSFT  ,KC_LNG1  , MO(L_SYM) ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      KC_BSPC,LT(L_NAV,KC_ENT), _______  ,  _______ , _______           , LT(L_SYM,KC_GRAVE)
   ),
 
   // Layer 1: Navigation
@@ -110,7 +110,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_F11   , KC_F12   , _______      , _______  , _______  ,                             _______  , TD(TD_SS1)   , TD(TD_SS2)   , _______  , _______          ,
     KC_F1    , KC_F2    , KC_F3    , KC_F4    , KC_F5    ,                             KC_F6    , KC_F7    , KC_F8    , KC_F9    , KC_F10  ,
     _______  , _______  , _______  , LAY_TOG  , _______  ,                             CPI_D100 , CPI_I100 , SCRL_DVD , SCRL_DVI , KBC_SAVE,
-    _______  , _______  , _______  , _______  , _______  , _______,                             _______  , _______  , _______  , _______  , KBC_RST, _______
+    _______  , _______  , _______  , _______  , _______  , _______,                             _______  , _______  , _______  , _______  , _______, KBC_RST
   ),
 
   // Layer 3: Mouse


### PR DESCRIPTION
## 概要

Keyball39 masatomix キーマップで、右親指最外側キーが無反応だった問題を修正。

## 背景

Keyball39 `LAYOUT_right_ball` の親指行物理配置:
- 左 6キー: L30-L35（全て物理存在）
- 右 3キー: R35, R34, **R30**（R31/R32/R33 はボール領域で物理非存在）

Keyball44 では右親指外側が R31 (col 1) だが、Keyball39 ではボール配置により R30 (col 0)。#792 で Keyball44 の keymap をコピーした際、この違いを考慮せず:

- R31 = `LT(L_SYM, KC_GRAVE)` / `KBC_RST`（物理キーに対応しない）
- R30 = `KC_NO`（実際の外側物理キーが死にキー化）

になっていた。結果、右外側親指で SYM レイヤートグル／GRAVE／KBC_RST が押せない状態。

## 修正内容

右親指のみスワップ（左は一切変更なし）:

**L_BASE row 3:**
- R31: `LT(L_SYM, KC_GRAVE)` → `_______`
- R30: `KC_NO` → `LT(L_SYM, KC_GRAVE)`

**L_FKEYS row 3:**
- R31: `KBC_RST` → `_______`
- R30: `_______` → `KBC_RST`

他レイヤー（NAV/MOUSE/SYM）の R31/R30 は元々 `_______` のため変更不要。

## 動作確認

- ビルド成功: 28274/28672 (98%, 398 bytes free)
- 実機動作確認: ユーザーがフラッシュ後に確認

## 関連

- Closes masatomix/task#803
- Follow-up to #59 (task#792)

🤖 Generated with [Claude Code](https://claude.com/claude-code)