### PR TITLE
feat(keyball39): 左親指配置変更 & Backspace Mod-Morph撤廃 (task#809)

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/keymap.c
@@ -94,7 +94,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     KC_Q       , KC_W     , KC_E     , KC_R      , KC_T ,                       KC_Y     , KC_U     , KC_I     , KC_O     , KC_P            ,
     LGUI_T(KC_A), LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), LT(L_MOUSE,KC_G) ,  KC_H     , RSFT_T(KC_J), RCTL_T(KC_K), RALT_T(KC_L), RGUI_T(KC_SCLN) ,
     KC_Z       , KC_X     , KC_C     , KC_V      , KC_B ,                       KC_N     , KC_M     , KC_COMM  , KC_DOT   , LT(L_MOUSE,KC_SLSH),
-    KC_NO      , KC_LSFT  ,KC_LNG1  , MO(L_SYM) ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      KC_BSPC,LT(L_NAV,KC_ENT), _______  ,  _______ , _______           , LT(L_SYM,KC_GRAVE)
+    KC_LSFT    , KC_TAB   ,KC_LNG1  , MO(L_SYM) ,LT(L_NAV,KC_SPC),LT(L_FKEYS,KC_LNG2),      KC_BSPC,LT(L_NAV,KC_ENT), _______  ,  _______ , _______           , LT(L_SYM,KC_GRAVE)
   ),
 
   // Layer 1: Navigation
@@ -170,28 +170,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         #ifdef PRECISION_ENABLE
         case PRC_SW:  precision_switch(record->event.pressed); return false;
         #endif
-
-        // Mod-Morph: Shift+Backspace → Delete
-        case KC_BSPC: {
-            static bool del_registered = false;
-            if (record->event.pressed) {
-                uint8_t mods = get_mods();
-                if (mods & MOD_MASK_SHIFT) {
-                    del_mods(MOD_MASK_SHIFT);
-                    register_code(KC_DEL);
-                    del_registered = true;
-                    set_mods(mods);
-                    return false;
-                }
-            } else {
-                if (del_registered) {
-                    unregister_code(KC_DEL);
-                    del_registered = false;
-                    return false;
-                }
-            }
-            return true;
-        }
 
         default: break;
     }


### PR DESCRIPTION
## Summary

- L_BASE 左親指の物理 L30 を活用: `L30=KC_NO → KC_LSFT / L31=LSFT → KC_TAB / L32=LNG1 (同)`
- `process_record_user` から Backspace Mod-Morph (Shift→Del) を削除。Shift+矢印で選択→BSPC で削除のワークフローを回復

## Build

- `make keyball/keyball39:masatomix` 成功
- Firmware size: **28218/28672 (98%, 454 bytes free)**

## Related

- masatomix/task#809 親Issue
- masatomix/task#723 K44側でMod-Morph導入した経緯（K44は維持、K39のみ撤廃）
- masatomix/task#792 K44→K39 移植（Mod-Morph 引き継ぎ元）

## Test plan

- [ ] L30 タップで Shift が効く
- [ ] L31 タップで Tab が入力される
- [ ] Shift+BSPC が通常の Backspace として動作（Del にならない）
- [ ] Shift+矢印で選択→BSPC で削除が成立

🤖 Generated with [Claude Code](https://claude.com/claude-code)