### PR TITLE
feat(keyball39): os_detection で Windows(JIS)/Mac(US) 記号を自動両対応

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/keymap.c
@@ -34,6 +34,39 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "precision.c"
 #endif
 
+#include "os_detection.h"
+#include "deferred_exec.h"
+#include "translate_ansi_to_jis.h"
+
+// OS 自動判別フラグ: true=Windows(JIS翻訳), false=Mac/iOS/その他(US素通し) (#1019)
+static bool is_windows = false;
+
+// 接続先 OS を判別して is_windows を設定する deferred コールバック。
+//  - master だけが USB/ホスト情報を持つので master 限定。
+//  - Apple Silicon Mac は OS_IOS と判定されるため OS_MACOS と同一扱い。
+//  - 判定不能(OS_UNSURE)の間は 200ms 後に再試行。
+//  - OS_UNSURE/Linux は US 素通しを既定に（判定失敗でも Mac が壊れない）。
+static uint32_t detect_os_cb(uint32_t trigger_time, void *cb_arg) {
+    if (!is_keyboard_master()) return 0;
+    switch (detected_host_os()) {
+        case OS_WINDOWS:
+            is_windows = true;
+            return 0;
+        case OS_MACOS:
+        case OS_IOS:
+        case OS_LINUX:
+            is_windows = false;
+            return 0;
+        default:  // OS_UNSURE
+            return 200;
+    }
+}
+
+// Tap Dance / LT タップから共有する US->JIS 変換（Windows のときだけ翻訳）(#1019)
+static uint16_t td_kc(uint16_t kc) {
+    return is_windows ? a2j_translate(kc) : kc;
+}
+
 // Combo: J+K → Esc (#738), D+F → Tab (#749) 5列移行準備
 const uint16_t PROGMEM jk_combo[] = {RSFT_T(KC_J), RCTL_T(KC_K), COMBO_END};
 const uint16_t PROGMEM df_combo[] = {LCTL_T(KC_D), LSFT_T(KC_F), COMBO_END};
@@ -76,15 +109,35 @@ void td_ss2_finished(tap_dance_state_t *state, void *user_data) {
     }
 }
 
+// OS 連動の「1タップ=kc1 / 2タップ=kc2」Tap Dance。
+// QMK の tap_dance_pair_* と同じ挙動で、出力時に td_kc() で JIS 変換を挟む (#1019)。
+void td_pair_a2j_each(tap_dance_state_t *state, void *user_data) {
+    tap_dance_pair_t *pair = (tap_dance_pair_t *)user_data;
+    if (state->count == 2) {
+        register_code16(td_kc(pair->kc2));
+        state->finished = true;
+    }
+}
+void td_pair_a2j_finished(tap_dance_state_t *state, void *user_data) {
+    tap_dance_pair_t *pair = (tap_dance_pair_t *)user_data;
+    register_code16(td_kc(state->count == 1 ? pair->kc1 : pair->kc2));
+}
+void td_pair_a2j_reset(tap_dance_state_t *state, void *user_data) {
+    tap_dance_pair_t *pair = (tap_dance_pair_t *)user_data;
+    unregister_code16(td_kc(state->count == 1 ? pair->kc1 : pair->kc2));
+}
+#define ACTION_TD_PAIR_A2J(kc1, kc2) \
+    { .fn = {td_pair_a2j_each, td_pair_a2j_finished, td_pair_a2j_reset, NULL}, .user_data = (void *)&((tap_dance_pair_t){kc1, kc2}) }
+
 tap_dance_action_t tap_dance_actions[] = {
     [TD_SS1] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, td_ss1_finished, NULL),
     [TD_SS2] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, td_ss2_finished, NULL),
-    [TD_PRN] = ACTION_TAP_DANCE_DOUBLE(S(KC_9), S(KC_0)),         // ( )
-    [TD_CBR] = ACTION_TAP_DANCE_DOUBLE(S(KC_LBRC), S(KC_RBRC)),   // { }
-    [TD_BRC] = ACTION_TAP_DANCE_DOUBLE(KC_LBRC, KC_RBRC),         // [ ]
-    [TD_QUO] = ACTION_TAP_DANCE_DOUBLE(KC_QUOT, S(KC_QUOT)),     // ' "
-    [TD_EXLM] = ACTION_TAP_DANCE_DOUBLE(S(KC_1), S(KC_GRV)),     // ! ~
-    [TD_AT]   = ACTION_TAP_DANCE_DOUBLE(S(KC_2), KC_GRV),        // @ `
+    [TD_PRN] = ACTION_TD_PAIR_A2J(S(KC_9), S(KC_0)),         // ( )
+    [TD_CBR] = ACTION_TD_PAIR_A2J(S(KC_LBRC), S(KC_RBRC)),   // { }
+    [TD_BRC] = ACTION_TD_PAIR_A2J(KC_LBRC, KC_RBRC),         // [ ]
+    [TD_QUO] = ACTION_TD_PAIR_A2J(KC_QUOT, S(KC_QUOT)),      // ' "
+    [TD_EXLM] = ACTION_TD_PAIR_A2J(S(KC_1), S(KC_GRV)),      // ! ~
+    [TD_AT]   = ACTION_TD_PAIR_A2J(S(KC_2), KC_GRV),         // @ `
 };
 
 // clang-format off
@@ -167,6 +220,11 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
+    // Windows(JIS) のときは US->JIS 変換を最優先で適用 (#1019)。
+    // a2j は mod-tap 範囲までの記号キーを翻訳する（LT/TapDance は別途下で対応）。
+    if (is_windows) {
+        if (!process_record_user_a2j(keycode, record)) return false;  // HANDLED
+    }
     switch (keycode) {
         #ifdef LAYER_LED_ENABLE
         case LAY_TOG: toggle_layer_led(record->event.pressed); return true;
@@ -174,6 +232,15 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         #ifdef PRECISION_ENABLE
         case PRC_SW:  precision_switch(record->event.pressed); return false;
         #endif
+
+        // base layer の ` (LT(L_SYM,KC_GRAVE)) のタップを JIS 変換 (#1019)。
+        // a2j は LT 範囲(>QK_MOD_TAP_MAX)を扱わないためここで対応。ホールド(レイヤ)は素通し。
+        case LT(L_SYM, KC_GRAVE):
+            if (is_windows && record->tap.count && record->event.pressed) {
+                tap_code16(a2j_translate(KC_GRV));
+                return false;
+            }
+            break;
 
         default: break;
     }
@@ -223,4 +290,7 @@ void keyboard_post_init_user(void) {
 #endif
     // スクロールスナップのデフォルトを FREE に設定（縦横両方動くように） (#761)
     keyball_set_scrollsnap_mode(KEYBALL_SCROLLSNAP_MODE_FREE);
+
+    // 接続先 OS 判別を開始（USB が落ち着くよう 500ms 後）(#1019)
+    defer_exec(500, detect_os_cb, NULL);
 }

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/rules.mk
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/rules.mk
@@ -2,7 +2,10 @@ RGBLIGHT_ENABLE = no
 
 OLED_ENABLE = yes
 
-VIA_ENABLE = yes
+# VIA は GUI ツール不使用方針 (#1019) のため無効化。
+# os_detection / Key Override 等は VIA(Vial 含む) では扱えず、
+# dynamic keymap を切ってフラッシュ容量を確保する。
+VIA_ENABLE = no
 
 EXTRAKEY_ENABLE = yes
 
@@ -11,3 +14,10 @@ EXTRAKEY_ENABLE = yes
 TAP_DANCE_ENABLE = yes
 
 COMBO_ENABLE = yes
+
+# OS 自動判別 (Windows=JIS / Mac=US 素通し) (#1019)
+OS_DETECTION_ENABLE = yes
+DEFERRED_EXEC_ENABLE = yes
+
+# US(ANSI) -> JIS host 変換テーブル
+SRC += translate_ansi_to_jis.c

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/translate_ansi_to_jis.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/translate_ansi_to_jis.c
@@ -1,0 +1,102 @@
+// US(ANSI) keymap -> JIS host translation.
+//
+// Based on m47ch4n/qmk-translate-ansi-to-jis (MIT License).
+//   https://github.com/m47ch4n/qmk-translate-ansi-to-jis
+//   Copyright (c) m47ch4n
+// Vendored & extended for this keymap (#1019): internal symbols are made
+// static to avoid clashing with QMK's global namespace, and a2j_translate()
+// is exported so Tap Dance / LT callbacks can share the one table.
+
+#include QMK_KEYBOARD_H
+#include "translate_ansi_to_jis.h"
+
+#define HANDLED false
+#define NOT_HANDLED true
+
+// ANSI keycode -> JIS keycode. Keyed on the (shift-embedded) ANSI keycode,
+// e.g. KC_AT == S(KC_2), so process_record_user_a2j re-derives the embedded
+// keycode from get_mods() before looking it up.
+static const uint16_t translate_map[][2] = {
+    // clang-format off
+    // ANSI    JIS
+    {KC_EQL,  S(KC_MINS)},
+    {KC_LBRC, KC_RBRC},
+    {KC_BSLS, KC_INT3},
+    {KC_RBRC, KC_NUHS},
+    {KC_QUOT, S(KC_7)},
+    {KC_GRV,  S(KC_LBRC)},
+    {KC_RPRN, S(KC_9)},
+    {KC_AT,   KC_LBRC},
+    {KC_CIRC, KC_EQL},
+    {KC_AMPR, S(KC_6)},
+    {KC_ASTR, S(KC_QUOT)},
+    {KC_LPRN, S(KC_8)},
+    {KC_PLUS, S(KC_SCLN)},
+    {KC_UNDS, S(KC_INT1)},
+    {KC_LCBR, S(KC_RBRC)},
+    {KC_PIPE, S(KC_INT3)},
+    {KC_RCBR, S(KC_NUHS)},
+    {KC_COLN, KC_QUOT},
+    {KC_DQT,  S(KC_2)},
+    {KC_TILD, S(KC_EQL)},
+    // clang-format on
+};
+
+static const size_t a2j_rows = sizeof(translate_map) / sizeof(translate_map[0]);
+
+// Raw table lookup. Returns 0 when there is no mapping.
+static uint16_t a2j_find(uint16_t kc) {
+    for (size_t index = 0; index < a2j_rows; index++) {
+        if (translate_map[index][0] == kc) return translate_map[index][1];
+    }
+    return 0;
+}
+
+uint16_t a2j_translate(uint16_t kc) {
+    uint16_t jis = a2j_find(kc);
+    return jis ? jis : kc;
+}
+
+#define PUSH_NONE 0
+// Assumes that multiple symbolic keys will never be used at the same time.
+static uint16_t pushing_shift_embeded_basic_kc = PUSH_NONE;
+
+bool process_record_user_a2j(uint16_t kc, keyrecord_t *record) {
+    if (kc > QK_MOD_TAP_MAX) return NOT_HANDLED;
+
+    uint8_t mods_kc  = QK_MODS_GET_MODS(kc);
+    uint8_t basic_kc = QK_MODS_GET_BASIC_KEYCODE(kc);
+
+    if (record->event.pressed) {
+        uint8_t  mod_state                    = get_mods();
+        bool     shift_state_or_shift_embeded = (mod_state | mods_kc) & MOD_MASK_SHIFT;
+        uint16_t shift_embeded_basic_kc       = shift_state_or_shift_embeded ? S((uint16_t)basic_kc) : basic_kc;
+        uint16_t shift_embeded_basic_jis_kc   = a2j_find(shift_embeded_basic_kc);
+
+        if (!shift_embeded_basic_jis_kc) return NOT_HANDLED;
+
+        if (pushing_shift_embeded_basic_kc != PUSH_NONE) {
+            uint16_t pushing_basic_kc = QK_MODS_GET_BASIC_KEYCODE(pushing_shift_embeded_basic_kc);
+            unregister_code16(pushing_basic_kc);
+        }
+
+        if (mod_state & MOD_MASK_SHIFT) {
+            del_mods(MOD_MASK_SHIFT);
+            register_code16(shift_embeded_basic_jis_kc);
+            set_mods(mod_state);
+        } else {
+            register_code16(shift_embeded_basic_jis_kc);
+        }
+        pushing_shift_embeded_basic_kc = shift_embeded_basic_kc;
+        return HANDLED;
+    }
+
+    // if keycode is the same as previous one without mods.
+    if (basic_kc == QK_MODS_GET_BASIC_KEYCODE(pushing_shift_embeded_basic_kc)) {
+        unregister_code16(a2j_find(pushing_shift_embeded_basic_kc));
+        pushing_shift_embeded_basic_kc = PUSH_NONE;
+        return HANDLED;
+    }
+
+    return NOT_HANDLED;
+}

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/translate_ansi_to_jis.h
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/translate_ansi_to_jis.h
@@ -1,0 +1,23 @@
+// US(ANSI) keymap -> JIS host translation.
+//
+// Based on m47ch4n/qmk-translate-ansi-to-jis (MIT License).
+//   https://github.com/m47ch4n/qmk-translate-ansi-to-jis
+// Vendored into this keymap and extended with a2j_translate() so that the
+// same translation table can also be reused from Tap Dance / Layer-Tap
+// callbacks (which bypass process_record_user). (#1019)
+
+#pragma once
+
+#include "quantum.h"
+
+// Route a key event through the ANSI->JIS translation table.
+// Returns false (HANDLED) if the key was translated & emitted here,
+// true (NOT_HANDLED) otherwise (caller should keep processing).
+// Call this only when the connected host uses a JIS layout (Windows).
+bool process_record_user_a2j(uint16_t keycode, keyrecord_t *record);
+
+// Translate a single (possibly shift-embedded) keycode to its JIS
+// equivalent. Returns the JIS keycode if the table has a mapping,
+// otherwise returns kc unchanged. For use from Tap Dance / LT tap
+// callbacks that emit via tap_code16() and never reach a2j above.
+uint16_t a2j_translate(uint16_t kc);


### PR DESCRIPTION
接続先 OS を `os_detection` で自動判別し、**Windows(JIS) のときだけ US→JIS 記号変換**を行う。Mac/iOS は US 素通し（変換ゼロ）で従来通り。1ファーム・自動・OS設定/GUIツール不要。

## 方式（当初の Key Override から変更）
- このキーマップは記号を symbol layer 上の合成キーコード `S(KC_n)` で出力しており、`process_key_override` は物理 mod + 基本キーでしか発火しないため**機能しない**（QMK ソースで確認）。
- 代わりにコミュニティ定番の **US→JIS 変換テーブル方式**を採用。[m47ch4n/qmk-translate-ansi-to-jis](https://github.com/m47ch4n/qmk-translate-ansi-to-jis)（MIT）を vendor し、TapDance/LT から共有するため `a2j_translate()` を export 追加。全20記号対を単一テーブルで包括対応。

## 実装
- os_detection: master 限定・`OS_UNSURE` リトライ・**Apple Silicon の `OS_IOS` は `OS_MACOS` と同一扱い**・UNSURE/Linux は US 素通し既定（判定失敗でも Mac 安全）。
- 取りこぼし対策: a2j を通らない TapDance(`@`/`!~`/`()`/`{}`/`[]`/`'"`)と base の `LT(L_SYM,KC_GRAVE)` タップ(`)も同一テーブルで変換。
- `VIA_ENABLE=no`（GUI 不使用方針 + フラッシュ容量確保）。ビルド 27002/28672 (94%, 1670 bytes free)。

## 検証
- ✅ 実機確認済み: US-Mac で素通し、JIS-Windows で正しい記号（`Shift+2`→`@` 等）。

## 関連
- 設計・実装ドキュメント / Issue: masatomix/task#1019
- 変更前ベースライン tag: `keyball39/v1.1.0`