### PR TITLE
fix(keyball39): a2j が Mod-Tap を誤変換し RSFT_T(KC_7) タップが & になる

### DIFF
--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/keymap.c
@@ -223,7 +223,30 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     // Windows(JIS) のときは US->JIS 変換を最優先で適用 (#1019)。
     // a2j は mod-tap 範囲までの記号キーを翻訳する（LT/TapDance は別途下で対応）。
     if (is_windows) {
+        // 1) 素キー / QK_MODS の記号 (S(KC_n), KC_BSLS, KC_EQL 等) を JIS へ変換。
         if (!process_record_user_a2j(keycode, record)) return false;  // HANDLED
+
+        // 2) Mod-Tap / Layer-Tap の「タップ」が JIS で divergent な記号になる場合を変換。
+        //    a2j は MT/LT (>QK_MODS_MAX) を扱わないためここで対応 (#1024)。
+        //    例: Shift+; → :  /  base の ` → JIS `  /  Shift+` → ~ 。
+        //    タップ確定時(record->tap.count)のみ。ホールド(modifier/レイヤ)は素通し。
+        if (record->event.pressed && record->tap.count &&
+            (IS_QK_MOD_TAP(keycode) || IS_QK_LAYER_TAP(keycode))) {
+            uint8_t  basic = QK_MODS_GET_BASIC_KEYCODE(keycode);
+            uint8_t  mods  = get_mods();
+            uint16_t eff   = (mods & MOD_MASK_SHIFT) ? S(basic) : (uint16_t)basic;
+            uint16_t jis   = a2j_translate(eff);
+            if (jis != eff) {  // divergent な記号のときだけ差し替え
+                if (mods & MOD_MASK_SHIFT) {
+                    del_mods(MOD_MASK_SHIFT);  // JIS 側の Shift 要否は jis 側が内包
+                    tap_code16(jis);
+                    set_mods(mods);
+                } else {
+                    tap_code16(jis);
+                }
+                return false;
+            }
+        }
     }
     switch (keycode) {
         #ifdef LAYER_LED_ENABLE
@@ -232,15 +255,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         #ifdef PRECISION_ENABLE
         case PRC_SW:  precision_switch(record->event.pressed); return false;
         #endif
-
-        // base layer の ` (LT(L_SYM,KC_GRAVE)) のタップを JIS 変換 (#1019)。
-        // a2j は LT 範囲(>QK_MOD_TAP_MAX)を扱わないためここで対応。ホールド(レイヤ)は素通し。
-        case LT(L_SYM, KC_GRAVE):
-            if (is_windows && record->tap.count && record->event.pressed) {
-                tap_code16(a2j_translate(KC_GRV));
-                return false;
-            }
-            break;
 
         default: break;
     }

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/keymap.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/keymap.c
@@ -129,6 +129,17 @@ void td_pair_a2j_reset(tap_dance_state_t *state, void *user_data) {
 #define ACTION_TD_PAIR_A2J(kc1, kc2) \
     { .fn = {td_pair_a2j_each, td_pair_a2j_finished, td_pair_a2j_reset, NULL}, .user_data = (void *)&((tap_dance_pair_t){kc1, kc2}) }
 
+// ── メンテ注意: JIS 自動変換と「直接送出」経路について (#1019/#1024) ───────────
+//  普通の keymap エントリ（素キー / S(KC_n) / Mod-Tap / Layer-Tap）は
+//  process_record_user の P1(a2j)/P2(MT-LT) が「実効キーコード＋実際の修飾」から
+//  自動で US→JIS 変換する。キー配置や種類を変えてもロジック変更は不要。
+//  ただし TapDance コールバックや自前マクロ等で tap_code16()/register_code16() を
+//  使って記号を「直接送出」する経路は process_record_user を通らず a2j が拾えない。
+//  → 記号を出す TapDance/マクロを足す時は必ず td_kc()（=a2j_translate()）で包むこと。
+//     例: 下記 ACTION_TD_PAIR_A2J は td_kc() 経由なので OK。素の
+//     ACTION_TAP_DANCE_DOUBLE で記号を出すと Windows(JIS) で化ける。
+//     スクショ TD(TD_SS1/2) は機能キー(Cmd+Shift+4 等)で記号でないため包む必要なし。
+// ───────────────────────────────────────────────────────────────────────────
 tap_dance_action_t tap_dance_actions[] = {
     [TD_SS1] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, td_ss1_finished, NULL),
     [TD_SS2] = ACTION_TAP_DANCE_FN_ADVANCED(NULL, td_ss2_finished, NULL),

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/translate_ansi_to_jis.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/translate_ansi_to_jis.c
@@ -62,7 +62,10 @@ uint16_t a2j_translate(uint16_t kc) {
 static uint16_t pushing_shift_embeded_basic_kc = PUSH_NONE;
 
 bool process_record_user_a2j(uint16_t kc, keyrecord_t *record) {
-    if (kc > QK_MOD_TAP_MAX) return NOT_HANDLED;
+    // Mod-Tap / Layer-Tap (>QK_MODS_MAX) は対象外。これらの mod ニブルを
+    // QK_MODS_GET_MODS で読むと埋め込み Shift と誤判定し、例えば RSFT_T(KC_7)
+    // のタップが S(KC_7)=& と誤変換される (#1024)。QK_MODS と素のキーのみ扱う。
+    if (kc > QK_MODS_MAX) return NOT_HANDLED;
 
     uint8_t mods_kc  = QK_MODS_GET_MODS(kc);
     uint8_t basic_kc = QK_MODS_GET_BASIC_KEYCODE(kc);

--- a/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/translate_ansi_to_jis.c
+++ b/qmk_firmware/keyboards/keyball/keyball39/keymaps/masatomix/translate_ansi_to_jis.c
@@ -64,7 +64,8 @@ static uint16_t pushing_shift_embeded_basic_kc = PUSH_NONE;
 bool process_record_user_a2j(uint16_t kc, keyrecord_t *record) {
     // Mod-Tap / Layer-Tap (>QK_MODS_MAX) は対象外。これらの mod ニブルを
     // QK_MODS_GET_MODS で読むと埋め込み Shift と誤判定し、例えば RSFT_T(KC_7)
-    // のタップが S(KC_7)=& と誤変換される (#1024)。QK_MODS と素のキーのみ扱う。
+    // のタップが S(KC_7)=& と誤変換される (#1024)。QK_MODS と素のキーのみ扱い、
+    // Mod-Tap/Layer-Tap のタップは keymap.c 側(process_record_user)で変換する。
     if (kc > QK_MODS_MAX) return NOT_HANDLED;
 
     uint8_t mods_kc  = QK_MODS_GET_MODS(kc);


### PR DESCRIPTION
## 不具合
#1019 の os_detection 対応で、**Windows 判定時のみ** L_SYM 右手・中段・左から2個目の `RSFT_T(KC_7)`（タップ=7）が **`&`** を出力していた。

## 原因
`process_record_user_a2j` のゲート `if (kc > QK_MOD_TAP_MAX)` が **Mod-Tap キーコード(0x2000〜)を変換対象に通していた**。`QK_MODS_GET_MODS()` が Mod-Tap の mod ニブルを誤読 → 右Shift ビットを埋め込み Shift と誤判定 → `S(KC_7)=&` を再構成 → JIS `&` に変換。

## 修正
ゲートを `QK_MODS_MAX`(0x1FFF) に変更し **Mod-Tap/Layer-Tap を除外**。記号(`S(KC_n)`=QK_MODS / 素のキー)は従来通り変換、Mod-Tap タップ(数字/文字)は素通し。

## 検証
- ビルド OK: 27000/28672 (94%)。
- 要実機確認: Windows で `RSFT_T(KC_7)` タップ=`7`、他記号(`@ ^ & * ( )` 等)は引き続き正しい、Mac 素通し維持。

relates to masatomix/task#1024, masatomix/task#1019